### PR TITLE
Set "C" order of interpolated arrays explicitly

### DIFF
--- a/geotiepoints/interpolator.py
+++ b/geotiepoints/interpolator.py
@@ -251,8 +251,8 @@ class Interpolator(object):
                                       kx=self.kx_,
                                       ky=self.ky_)
 
-            self.new_data[num] = spl.ev(xpoints.ravel(), ypoints.ravel())
-            self.new_data[num] = self.new_data[num].reshape(xpoints.shape).T
+            new_data_ = spl.ev(xpoints.ravel(), ypoints.ravel())
+            self.new_data[num] = new_data_.reshape(xpoints.shape).T.copy(order='C')
 
     def _interp1d(self):
         """Interpolate in one dimension.

--- a/geotiepoints/tests/test_interpolator.py
+++ b/geotiepoints/tests/test_interpolator.py
@@ -118,6 +118,17 @@ class TestInterpolator(unittest.TestCase):
                                               [1.,  3.,  5.,  7.,  9.],
                                               [1.4,  3.4,  5.4,  7.4,  9.4]])))
 
+    def test_results_in_c_order(self):
+        lons = np.arange(10).reshape((2, 5), order="F")
+        lats = np.arange(10).reshape((2, 5), order="C")
+        lines = np.array([2, 7])
+        cols = np.array([2, 7, 12, 17, 22])
+        hlines = np.arange(10)
+        hcols = np.arange(24)
+        satint = Interpolator((lons, lats), (lines, cols), (hlines, hcols))
+        interp_results = satint.interpolate()
+        assert interp_results[0].flags['C_CONTIGUOUS'] is True
+
     # def test_fill_row_borders(self):
     #     lons = np.arange(20).reshape((4, 5), order="F")
     #     lats = np.arange(20).reshape((4, 5), order="C")


### PR DESCRIPTION
Addressing issue #5

It appears that scipy's spline interpolator returns an array that are in F and C
order simultaneously. Transposing and viewing the array converts it into
F-contiguous array. By specifying the order explicitly we convert it to
C order.

