### PR TITLE
Add support for modis l2 geolocation interpolation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,8 @@ language: python
 env:
   global:
   - PYTHON_VERSION=$PYTHON_VERSION
-  - NUMPY_VERSION=stable
   - MAIN_CMD='python setup.py'
-  - CONDA_DEPENDENCIES='cython pandas scipy numpy coveralls coverage h5py mock dask xarray'
+  - CONDA_DEPENDENCIES='cython pandas scipy coveralls coverage h5py mock dask xarray'
   - PIP_DEPENDENCIES=''
   - SETUP_XVFB=False
   - EVENT_TYPE='push pull_request'

--- a/geotiepoints/tests/test_modisinterpolator.py
+++ b/geotiepoints/tests/test_modisinterpolator.py
@@ -63,6 +63,16 @@ class TestModisInterpolator(unittest.TestCase):
         self.assertTrue(np.allclose(lon1, lons, atol=1e-2))
         self.assertTrue(np.allclose(lat1, lats, atol=1e-2))
 
+        # Test level 2
+        lat5 = lat1[2::5, 2:-5:5]
+        lon5 = lon1[2::5, 2:-5:5]
+
+        satz5 = satz1[2::5, 2:-5:5]
+        lons, lats = modis_5km_to_1km(lon5, lat5, satz5)
+        self.assertTrue(np.allclose(lon1, lons, atol=1e-2))
+        self.assertTrue(np.allclose(lat1, lats, atol=1e-2))
+
+
 def suite():
     """The suite for MODIS"""
     loader = unittest.TestLoader()


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
This PR add support for Modis L2 data through supporting 5km tiepoints of width 270 (instead of 271)

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
