### PR TITLE
Fix interpolation of symetrical tiepoints

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,0 +1,4 @@
+linters:
+  flake8:
+    python: 3
+    config: setup.cfg

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,6 @@ env:
   - CONDA_CHANNELS='conda-forge'
 matrix:
   include:
-    - env: PYTHON_VERSION=2.7
-      os: linux
-    - env: PYTHON_VERSION=2.7
-      os: osx
-      language: generic
     - env: PYTHON_VERSION=3.6
       os: linux
     - env: PYTHON_VERSION=3.6

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,13 +8,12 @@ environment:
     CONDA_CHANNELS: "conda-forge"
 
   matrix:
-    - PYTHON: "C:\\Python27_64"
-      PYTHON_VERSION: "2.7"
-      PYTHON_ARCH: "64"
-      NUMPY_VERSION: "stable"
-
     - PYTHON: "C:\\Python36_64"
       PYTHON_VERSION: "3.6"
+      PYTHON_ARCH: "64"
+      NUMPY_VERSION: "stable"
+    - PYTHON: "C:\\Python37_64"
+      PYTHON_VERSION: "3.7"
       PYTHON_ARCH: "64"
       NUMPY_VERSION: "stable"
 

--- a/geotiepoints/modisinterpolator.py
+++ b/geotiepoints/modisinterpolator.py
@@ -60,15 +60,17 @@ def compute_expansion_alignment(satz_a, satz_b, satz_c, satz_d):
     phi = (phi_a + phi_b) / 2
     zeta = compute_zeta(phi)
     theta = compute_theta(zeta, phi)
+    # Workaround for tiepoints symetrical about the subsatellite-track
+    denominator = np.where(theta_a == theta_b, theta_a * 2, theta_a - theta_b)
 
-    c_expansion = 4 * (((theta_a + theta_b) / 2 - theta) / (theta_a - theta_b))
+    c_expansion = 4 * (((theta_a + theta_b) / 2 - theta) / denominator)
 
     sin_beta_2 = scan_width / (2 * H)
 
     d = ((R + H) / R * np.cos(phi) - np.cos(zeta)) * sin_beta_2
     e = np.cos(zeta) - np.sqrt(np.cos(zeta) ** 2 - d ** 2)
 
-    c_alignment = 4 * e * np.sin(zeta) / (theta_a - theta_b)
+    c_alignment = 4 * e * np.sin(zeta) / denominator
 
     return c_expansion, c_alignment
 
@@ -194,7 +196,7 @@ class ModisInterpolator():
         c_ali_full = self.expand_tiepoint_array(c_ali, lines, cols)
 
         a_track = s_t
-        a_scan = (s_s + s_s * (1 - s_s) * c_exp_full + s_t*(1 - s_t) * c_ali_full)
+        a_scan = (s_s + s_s * (1 - s_s) * c_exp_full + s_t * (1 - s_t) * c_ali_full)
 
         res = []
 

--- a/geotiepoints/tests/test_modisinterpolator.py
+++ b/geotiepoints/tests/test_modisinterpolator.py
@@ -71,7 +71,14 @@ class TestModisInterpolator(unittest.TestCase):
         lons, lats = modis_5km_to_1km(lon5, lat5, satz5)
         self.assertTrue(np.allclose(lon1, lons, atol=1e-2))
         self.assertTrue(np.allclose(lat1, lats, atol=1e-2))
-        
+
+        # Test nans issue (#19)
+        satz1 = to_da(abs(np.linspace(-65.4, 65.4, 1354)).repeat(20).reshape(-1, 20).T)
+        lons, lats = modis_1km_to_500m(lon1, lat1, satz1)
+        self.assertFalse(np.any(np.isnan(lons.compute())))
+        self.assertFalse(np.any(np.isnan(lats.compute())))
+
+
     def test_poles_datum(self):
         import xarray as xr
         h5f = h5py.File(FILENAME_DATA, 'r')

--- a/geotiepoints/tests/test_modisinterpolator.py
+++ b/geotiepoints/tests/test_modisinterpolator.py
@@ -28,11 +28,13 @@ from geotiepoints.modisinterpolator import modis_1km_to_250m, modis_1km_to_500m,
 FILENAME_DATA = os.path.join(
     os.path.dirname(__file__), '../../testdata/modis_test_data.h5')
 
+
 def to_da(arr):
     import xarray as xr
     import dask.array as da
 
     return xr.DataArray(da.from_array(arr, chunks=4096), dims=['y', 'x'])
+
 
 class TestModisInterpolator(unittest.TestCase):
     def test_modis(self):
@@ -78,7 +80,6 @@ class TestModisInterpolator(unittest.TestCase):
         self.assertFalse(np.any(np.isnan(lons.compute())))
         self.assertFalse(np.any(np.isnan(lats.compute())))
 
-
     def test_poles_datum(self):
         import xarray as xr
         h5f = h5py.File(FILENAME_DATA, 'r')
@@ -106,6 +107,7 @@ def suite():
     mysuite.addTest(loader.loadTestsFromTestCase(TestModisInterpolator))
 
     return mysuite
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,7 @@ if __name__ == "__main__":
           packages=['geotiepoints'],
           # packages=find_packages(),
           setup_requires=['numpy'],
-          python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
+          python_requires='>=3.4',
           cmdclass=cmdclass,
 
           install_requires=requirements,


### PR DESCRIPTION
There is a bug atm where symetrical tiepoints generate nans on the subsatellite track.
This is a workaround. 

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
