### PR TITLE
Add simple lon/lat based MODIS interpolation

### DIFF
--- a/geotiepoints/geointerpolator.py
+++ b/geotiepoints/geointerpolator.py
@@ -1,27 +1,21 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-# Copyright (c) 2013 Martin Raspaud
-
-# Author(s):
-
-#   Martin Raspaud <martin.raspaud@smhi.se>
-
+#
+# Copyright (c) 2013-2021 Python-geotiepoints developers
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-"""Geographical interpolation (lon/lats).
-"""
+"""Geographical interpolation (lon/lats)."""
 
 import numpy as np
 from numpy import arccos, sign, rad2deg, sqrt, arcsin
@@ -29,14 +23,16 @@ from geotiepoints.interpolator import Interpolator
 
 EARTH_RADIUS = 6370997.0
 
+
 class GeoInterpolator(Interpolator):
-    """
-    Handles interpolation of geolocation from a grid of tie points.  It is
+    """Handles interpolation of geolocation from a grid of tie points.
+
+    It is
     preferable to have tie-points out till the edges if the tiepoint grid, but
     a method is provided to extrapolate linearly the tiepoints to the borders
     of the grid. The extrapolation is done automatically if it seems necessary.
 
-    Uses numpy, scipy, and optionally pyresample
+    Uses numpy, scipy, and optionally pyresample.
 
     The constructor takes in the tiepointed data as *data*, the
     *tiepoint_grid* and the desired *final_grid*. As optional arguments, one
@@ -45,10 +41,11 @@ class GeoInterpolator(Interpolator):
     along the y axis (this affects how the extrapolator behaves). If
     *chunksize* is set, don't forget to adjust the interpolation orders
     accordingly: the interpolation is indeed done globaly (not chunkwise).
-    """
-    def __init__(self, lon_lat_data, *args, **kwargs):
 
-        Interpolator.__init__(self, None, *args, **kwargs)
+    """
+
+    def __init__(self, lon_lat_data, *args, **kwargs):
+        super().__init__(None, *args, **kwargs)
         self.lon_tiepoint = None
         self.lat_tiepoint = None
         try:
@@ -56,7 +53,6 @@ class GeoInterpolator(Interpolator):
             self.set_tiepoints(lon_lat_data.lons, lon_lat_data.lats)
             xyz = lon_lat_data.get_cartesian_coords()
             self.tie_data = [xyz[:, :, 0], xyz[:, :, 1], xyz[:, :, 2]]
-
         except AttributeError:
             self.set_tiepoints(lon_lat_data[0], lon_lat_data[1])
             lons_rad = np.radians(self.lon_tiepoint)
@@ -66,41 +62,34 @@ class GeoInterpolator(Interpolator):
             z__ = EARTH_RADIUS * np.sin(lats_rad)
             self.tie_data = [x__, y__, z__]
 
-
-        self.new_data = []
-        for num in range(len(self.tie_data)):
-            self.new_data.append([])
-
+        self.new_data = [[]] * len(self.tie_data)
 
     def set_tiepoints(self, lon, lat):
-        """Defines the lon,lat tie points.
-        """
+        """Define the lon,lat tie points."""
         self.lon_tiepoint = lon
         self.lat_tiepoint = lat
 
     def interpolate(self):
+        """Run the interpolation."""
         newx, newy, newz = Interpolator.interpolate(self)
         lon = get_lons_from_cartesian(newx, newy)
         lat = get_lats_from_cartesian(newx, newy, newz)
         return lon, lat
 
+
 def get_lons_from_cartesian(x__, y__):
-    """Get longitudes from cartesian coordinates.
-    """
+    """Get longitudes from cartesian coordinates."""
     return rad2deg(arccos(x__ / sqrt(x__ ** 2 + y__ ** 2))) * sign(y__)
-    
+
+
 def get_lats_from_cartesian(x__, y__, z__, thr=0.8):
-    """Get latitudes from cartesian coordinates.
-    """
+    """Get latitudes from cartesian coordinates."""
     # if we are at low latitudes - small z, then get the
     # latitudes only from z. If we are at high latitudes (close to the poles)
     # then derive the latitude using x and y:
 
-    lats = np.where(np.logical_and(np.less(z__, thr * EARTH_RADIUS), 
+    lats = np.where(np.logical_and(np.less(z__, thr * EARTH_RADIUS),
                                    np.greater(z__, -1. * thr * EARTH_RADIUS)),
-                    90 - rad2deg(arccos(z__/EARTH_RADIUS)),
-                    sign(z__) *
-                    (90 - rad2deg(arcsin(sqrt(x__ ** 2 + y__ ** 2)
-                                         / EARTH_RADIUS))))
+                    90 - rad2deg(arccos(z__ / EARTH_RADIUS)),
+                    sign(z__) * (90 - rad2deg(arcsin(sqrt(x__ ** 2 + y__ ** 2) / EARTH_RADIUS))))
     return lats
-

--- a/geotiepoints/geointerpolator.py
+++ b/geotiepoints/geointerpolator.py
@@ -61,7 +61,7 @@ class GeoInterpolator(Interpolator):
     def interpolate(self):
         """Run the interpolation."""
         newx, newy, newz = super().interpolate()
-        lon, lat = xyz2lonlat(newx, newy, newz, low_lat_z=True)
+        lon, lat = xyz2lonlat(newx, newy, newz)
         return lon, lat
 
 
@@ -75,7 +75,7 @@ def lonlat2xyz(lons, lats, radius=EARTH_RADIUS):
     return x_coords, y_coords, z_coords
 
 
-def xyz2lonlat(x__, y__, z__, radius=EARTH_RADIUS, thr=0.8, low_lat_z=False):
+def xyz2lonlat(x__, y__, z__, radius=EARTH_RADIUS, thr=0.8, low_lat_z=True):
     """Get longitudes from cartesian coordinates."""
     lons = np.rad2deg(np.arccos(x__ / np.sqrt(x__ ** 2 + y__ ** 2))) * np.sign(y__)
     lats = np.sign(z__) * (90 - np.rad2deg(np.arcsin(np.sqrt(x__ ** 2 + y__ ** 2) / radius)))

--- a/geotiepoints/geointerpolator.py
+++ b/geotiepoints/geointerpolator.py
@@ -44,25 +44,19 @@ class GeoInterpolator(Interpolator):
     """
 
     def __init__(self, lon_lat_data, *args, **kwargs):
-        super().__init__(None, *args, **kwargs)
-        self.lon_tiepoint = None
-        self.lat_tiepoint = None
         try:
             # Maybe it's a pyresample object ?
-            self.set_tiepoints(lon_lat_data.lons, lon_lat_data.lats)
+            self.lon_tiepoint = lon_lat_data.lons
+            self.lat_tiepoint = lon_lat_data.lats
             xyz = lon_lat_data.get_cartesian_coords()
-            self.tie_data = [xyz[:, :, 0], xyz[:, :, 1], xyz[:, :, 2]]
+            tie_data = [xyz[:, :, 0], xyz[:, :, 1], xyz[:, :, 2]]
         except AttributeError:
-            self.set_tiepoints(lon_lat_data[0], lon_lat_data[1])
+            self.lon_tiepoint = lon_lat_data[0]
+            self.lat_tiepoint = lon_lat_data[1]
             x__, y__, z__ = lonlat2xyz(self.lon_tiepoint, self.lat_tiepoint)
-            self.tie_data = [x__, y__, z__]
+            tie_data = [x__, y__, z__]
 
-        self.new_data = [[]] * len(self.tie_data)
-
-    def set_tiepoints(self, lon, lat):
-        """Define the lon,lat tie points."""
-        self.lon_tiepoint = lon
-        self.lat_tiepoint = lat
+        super().__init__(tie_data, *args, **kwargs)
 
     def interpolate(self):
         """Run the interpolation."""

--- a/geotiepoints/interpolator.py
+++ b/geotiepoints/interpolator.py
@@ -104,10 +104,7 @@ class Interpolator(object):
         else:
             self.tie_data = list(data)
 
-        self.new_data = []
-        for num in range(len(self.tie_data)):
-            self.new_data.append([])
-
+        self.new_data = [[] for _ in self.tie_data]
         self.kx_, self.ky_ = kx_, ky_
 
     def fill_borders(self, *args):

--- a/geotiepoints/modisinterpolator.py
+++ b/geotiepoints/modisinterpolator.py
@@ -203,8 +203,6 @@ class ModisInterpolator(object):
         res = []
         datasets = lonlat2xyz(lon1, lat1)
         for data in datasets:
-            data_attrs = data.attrs
-            dims = data.dims
             data = data.data
             data = data.reshape((-1, cscan_len, cscan_full_width))
             data_a, data_b, data_c, data_d = get_corners(data)
@@ -217,9 +215,9 @@ class ModisInterpolator(object):
             data_2 = (1 - a_scan) * data_d + a_scan * data_c
             data = (1 - a_track) * data_1 + a_track * data_2
 
-            res.append(xr.DataArray(data, attrs=data_attrs, dims=dims))
-
-        return xyz2lonlat(*res)
+            res.append(data)
+        lon, lat = xyz2lonlat(*res)
+        return xr.DataArray(lon, dims=lon1.dims), xr.DataArray(lat, dims=lat1.dims)
 
 
 def modis_1km_to_250m(lon1, lat1, satz1):

--- a/geotiepoints/modisinterpolator.py
+++ b/geotiepoints/modisinterpolator.py
@@ -31,6 +31,8 @@ import dask.array as da
 import numpy as np
 import warnings
 
+from .geointerpolator import lonlat2xyz, xyz2lonlat
+
 R = 6371.
 # Aqua scan width and altitude in km
 scan_width = 10.00017
@@ -264,21 +266,3 @@ def modis_5km_to_250m(lon1, lat1, satz1):
                   "may result in poor quality")
     interp = ModisInterpolator(5000, 250, lon1.shape[1])
     return interp.interpolate(lon1, lat1, satz1)
-
-
-def lonlat2xyz(lons, lats):
-    """Convert lons and lats to cartesian coordinates."""
-    R = 6370997.0
-    x_coords = R * da.cos(da.deg2rad(lats)) * da.cos(da.deg2rad(lons))
-    y_coords = R * da.cos(da.deg2rad(lats)) * da.sin(da.deg2rad(lons))
-    z_coords = R * da.sin(da.deg2rad(lats))
-    return x_coords, y_coords, z_coords
-
-def xyz2lonlat(x__, y__, z__):
-    """Get longitudes from cartesian coordinates.
-    """
-    R = 6370997.0
-    lons = da.rad2deg(da.arccos(x__ / da.sqrt(x__ ** 2 + y__ ** 2))) * da.sign(y__)
-    lats = da.sign(z__) * (90 - da.rad2deg(da.arcsin(da.sqrt(x__ ** 2 + y__ ** 2) / R)))
-
-    return lons, lats

--- a/geotiepoints/modisinterpolator.py
+++ b/geotiepoints/modisinterpolator.py
@@ -201,16 +201,7 @@ class ModisInterpolator(object):
         a_scan = (s_s + s_s * (1 - s_s) * c_exp_full + s_t * (1 - s_t) * c_ali_full)
 
         res = []
-
-        sublat = lat1[::16, ::16]
-        sublon = lon1[::16, ::16]
-        to_cart = abs(sublat).max() > 60 or (sublon.max() - sublon.min()) > 180
-
-        if to_cart:
-            datasets = lonlat2xyz(lon1, lat1)
-        else:
-            datasets = [lon1, lat1]
-
+        datasets = lonlat2xyz(lon1, lat1)
         for data in datasets:
             data_attrs = data.attrs
             dims = data.dims
@@ -228,10 +219,7 @@ class ModisInterpolator(object):
 
             res.append(xr.DataArray(data, attrs=data_attrs, dims=dims))
 
-        if to_cart:
-            return xyz2lonlat(*res)
-        else:
-            return res
+        return xyz2lonlat(*res)
 
 
 def modis_1km_to_250m(lon1, lat1, satz1):

--- a/geotiepoints/simple_modis_interpolator.py
+++ b/geotiepoints/simple_modis_interpolator.py
@@ -151,7 +151,7 @@ def interpolate_geolocation_cartesian(lon_array, lat_array, res_factor=4):
     x, y = np.meshgrid(x, y)
     coordinates = np.array([y, x])  # Used by map_coordinates, major optimization
 
-    new_x = np.empty((num_rows * res_factor, num_cols * res_factor), dtype=np.float64)
+    new_x = np.empty((num_rows * res_factor, num_cols * res_factor), dtype=lon_array.dtype)
     new_y = new_x.copy()
     new_z = new_x.copy()
     nav_arrays = [(x_in, new_x), (y_in, new_y), (z_in, new_z)]

--- a/geotiepoints/simple_modis_interpolator.py
+++ b/geotiepoints/simple_modis_interpolator.py
@@ -100,10 +100,14 @@ def _rechunk_lonlat_if_needed(lon_data, lat_data):
     # take current chunk size and get a relatively similar chunk size
     row_chunks = lon_data.chunks[0]
     col_chunks = lon_data.chunks[1]
+    num_rows = lon_data.shape[0]
     num_cols = lon_data.shape[-1]
     good_row_chunks = all(x % ROWS_PER_SCAN == 0 for x in row_chunks)
     good_col_chunks = len(col_chunks) == 1 and col_chunks[0] != num_cols
     lonlat_same_chunks = lon_data.chunks == lat_data.chunks
+    if num_rows % ROWS_PER_SCAN != 0:
+        raise ValueError("Input longitude/latitude data does not consist of "
+                         "whole scans (10 rows per scan).")
     if good_row_chunks and good_col_chunks and lonlat_same_chunks:
         return lon_data, lat_data
 

--- a/geotiepoints/simple_modis_interpolator.py
+++ b/geotiepoints/simple_modis_interpolator.py
@@ -146,8 +146,8 @@ def interpolate_geolocation_cartesian(lon_array, lat_array, res_factor=4):
     # Create an array of indexes that we want our result to have
     x = np.arange(res_factor * num_cols, dtype=np.float32) * (1. / res_factor)
     # 0.375 for 250m, 0.25 for 500m
-    y = np.arange(res_factor * ROWS_PER_SCAN, dtype=np.float32) * (1. / res_factor) - (
-                res_factor * (1. / 16) + (1. / 8))
+    y = np.arange(res_factor * ROWS_PER_SCAN, dtype=np.float32) * \
+        (1. / res_factor) - (res_factor * (1. / 16) + (1. / 8))
     x, y = np.meshgrid(x, y)
     coordinates = np.array([y, x])  # Used by map_coordinates, major optimization
 

--- a/geotiepoints/simple_modis_interpolator.py
+++ b/geotiepoints/simple_modis_interpolator.py
@@ -200,51 +200,6 @@ def interpolate_geolocation_cartesian(lon_array, lat_array, res_factor=4):
     return new_lons.astype(lon_array.dtype), new_lats.astype(lon_array.dtype)
 
 
-# def interpolate_geolocation(nav_array):
-#     """Interpolate MODIS navigation from 1000m resolution to 250m.
-#
-#     Python rewrite of the IDL function ``MODIS_GEO_INTERP_250``
-#
-#     :param nav_array: MODIS 1km latitude array or 1km longitude array
-#
-#     :returns: MODIS 250m latitude array or 250m longitude array
-#     """
-#     num_rows,num_cols = nav_array.shape
-#     num_scans = int(num_rows / ROWS_PER_SCAN)
-#
-#     # Make a resulting array that is the right size for the new resolution
-#     result_array = np.empty((num_rows * res_factor, num_cols * res_factor), dtype=np.float32)
-#     x = np.arange(res_factor * num_cols, dtype=np.float32) * 0.25
-#     y = np.arange(res_factor * ROWS_PER_SCAN, dtype=np.float32) * 0.25 - 0.375
-#     x,y = np.meshgrid(x,y)
-#     coordinates = np.array([y,x]) # Used by map_coordinates, major optimization
-#
-#     # Interpolate each scan, one at a time, otherwise the math doesn't work well
-#     for scan_idx in range(num_scans):
-#         # Calculate indexes
-#         j0 = ROWS_PER_SCAN              * scan_idx
-#         j1 = j0 + ROWS_PER_SCAN
-#         k0 = ROWS_PER_SCAN * res_factor * scan_idx
-#         k1 = k0 + ROWS_PER_SCAN * res_factor
-#
-#         # Use bilinear interpolation for all 250 meter pixels
-#         map_coordinates(nav_array[ j0:j1, : ], coordinates, output=result_array[ k0:k1, : ], order=1, mode='nearest')
-#
-#         # Use linear extrapolation for the first two 250 meter pixels along track
-#         m = (result_array[ k0 + 5, : ] - result_array[ k0 + 2, : ]) / (y[5,0] - y[2,0])
-#         b = result_array[ k0 + 5, : ] - m * y[5,0]
-#         result_array[ k0 + 0, : ] = m * y[0,0] + b
-#         result_array[ k0 + 1, : ] = m * y[1,0] + b
-#
-#         # Use linear extrapolation for the last  two 250 meter pixels along track
-#         m = (result_array[ k0 + 37, : ] - result_array[ k0 + 34, : ]) / (y[37,0] - y[34,0])
-#         b = result_array[ k0 + 37, : ] - m * y[37,0]
-#         result_array[ k0 + 38, : ] = m * y[38,0] + b
-#         result_array[ k0 + 39, : ] = m * y[39,0] + b
-#
-#     return result_array
-
-
 def modis_1km_to_250m(lon1, lat1):
     """Interpolate MODIS geolocation from 1km to 250m resolution."""
     return interpolate_geolocation_cartesian(lon1, lat1, res_factor=4)

--- a/geotiepoints/simple_modis_interpolator.py
+++ b/geotiepoints/simple_modis_interpolator.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021 Python-geotiepoints developers
+#
+# This file is part of python-geotiepoints.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Interpolate MODIS 1km navigation arrays to 250m and 500m resolutions.
+
+The code used here is a rewrite of the IDL function ``MODIS_GEO_INTERP_250``
+used by Liam Gumley. It has been modified to convert coordinates to cartesian
+(X, Y, Z) coordinates first to avoid problems with the anti-meridian and poles.
+This code was originally part of the CSPP Polar2Grid project, but has been
+moved here for integration with Satpy and newer versions of Polar2Grid.
+
+This algorithm differs from the one in ``modisinterpolator`` as it only
+requires the original longitude and latitude arrays. This is useful in the
+case of reading the 250m or 500m MODIS L1b files or any MODIS L2 files without
+including the MOD03 geolocation file as there is no SensorZenith angle dataset
+in these files.
+
+"""
+
+import numpy as np
+from scipy.ndimage.interpolation import map_coordinates
+from .geointerpolator import get_lons_from_cartesian, get_lats_from_cartesian, EARTH_RADIUS
+
+# MODIS has 10 rows of data in the array for every scan line
+ROWS_PER_SCAN = 10
+
+
+def scanline_mapblocks(func):
+    """Convert dask array inputs to appropriate map_blocks calls.
+
+    This function, applied as a decorator, will call the wrapped function
+    using dask's ``map_blocks``. It will rechunk inputs when necessary to make
+    sure that the input chunks are entire scanlines to avoid incorrect
+    interpolation.
+
+    """
+    return func
+
+
+# TODO: Accept dask arrays or numpy arrays
+@scanline_mapblocks
+def interpolate_geolocation_cartesian(lon_array, lat_array, res_factor=4):
+    """Interpolate MODIS navigation from 1000m resolution to 250m.
+
+    Python rewrite of the IDL function ``MODIS_GEO_INTERP_250`` but converts to cartesian (X, Y, Z) coordinates
+    first to avoid problems with the anti-meridian/poles.
+
+    :param lon_array: MODIS 1km longitude array
+    :param lat_array: MODIS 1km latitude array
+
+    :returns: MODIS 250m latitude array or 250m longitude array
+
+    If we are going from 1000m to 250m we have 4 times the size of the original
+    If we are going from 1000m to 250m we have 2 times the size of the original
+    """
+    num_rows, num_cols = lon_array.shape
+    num_scans = int(num_rows / ROWS_PER_SCAN)
+
+    # TODO: Extract equivalent existing logic from geointerpolator.py and use that
+    lons_rad = np.radians(lon_array)
+    lats_rad = np.radians(lat_array)
+    x_in = EARTH_RADIUS * np.cos(lats_rad) * np.cos(lons_rad)
+    y_in = EARTH_RADIUS * np.cos(lats_rad) * np.sin(lons_rad)
+    z_in = EARTH_RADIUS * np.sin(lats_rad)
+
+    # Create an array of indexes that we want our result to have
+    x = np.arange(res_factor * num_cols, dtype=np.float32) * (1./res_factor)
+    # 0.375 for 250m, 0.25 for 500m
+    y = np.arange(res_factor * ROWS_PER_SCAN, dtype=np.float32) * (1./res_factor) - (res_factor * (1./16) + (1./8))
+    x,y = np.meshgrid(x,y)
+    coordinates = np.array([y,x]) # Used by map_coordinates, major optimization
+
+    new_x = np.empty((num_rows * res_factor, num_cols * res_factor), dtype=np.float64)
+    new_y = new_x.copy()
+    new_z = new_x.copy()
+    nav_arrays = [(x_in, new_x), (y_in, new_y), (z_in, new_z)]
+
+    # Interpolate each scan, one at a time, otherwise the math doesn't work well
+    for scan_idx in range(num_scans):
+        # Calculate indexes
+        j0 = ROWS_PER_SCAN * scan_idx
+        j1 = j0 + ROWS_PER_SCAN
+        k0 = ROWS_PER_SCAN * res_factor * scan_idx
+        k1 = k0 + ROWS_PER_SCAN * res_factor
+
+        for nav_array, result_array in nav_arrays:
+            # Use bilinear interpolation for all 250 meter pixels
+            map_coordinates(nav_array[ j0:j1, : ], coordinates, output=result_array[ k0:k1, : ], order=1, mode='nearest')
+
+            if res_factor == 4:
+                # Use linear extrapolation for the first two 250 meter pixels along track
+                m = (result_array[ k0 + 5, : ] - result_array[ k0 + 2, : ]) / (y[5,0] - y[2,0])
+                b = result_array[ k0 + 5, : ] - m * y[5,0]
+                result_array[ k0 + 0, : ] = m * y[0,0] + b
+                result_array[ k0 + 1, : ] = m * y[1,0] + b
+
+                # Use linear extrapolation for the last  two 250 meter pixels along track
+                m = (result_array[ k0 + 37, : ] - result_array[ k0 + 34, : ]) / (y[37,0] - y[34,0])
+                b = result_array[ k0 + 37, : ] - m * y[37,0]
+                result_array[ k0 + 38, : ] = m * y[38,0] + b
+                result_array[ k0 + 39, : ] = m * y[39,0] + b
+            else:
+                # 500m
+                # Use linear extrapolation for the first two 250 meter pixels along track
+                m = (result_array[ k0 + 2, : ] - result_array[ k0 + 1, : ]) / (y[2,0] - y[1,0])
+                b = result_array[ k0 + 2, : ] - m * y[2,0]
+                result_array[ k0 + 0, : ] = m * y[0,0] + b
+
+                # Use linear extrapolation for the last  two 250 meter pixels along track
+                m = (result_array[ k0 + 18, : ] - result_array[ k0 + 17, : ]) / (y[18,0] - y[17,0])
+                b = result_array[ k0 + 18, : ] - m * y[18,0]
+                result_array[ k0 + 19, : ] = m * y[19,0] + b
+
+    # Convert from cartesian to lat/lon space
+    new_lons = get_lons_from_cartesian(new_x, new_y)
+    new_lats = get_lats_from_cartesian(new_x, new_y, new_z)
+
+    return new_lons.astype(lon_array.dtype), new_lats.astype(lat_array.dtype)
+
+
+# def interpolate_geolocation(nav_array):
+#     """Interpolate MODIS navigation from 1000m resolution to 250m.
+#
+#     Python rewrite of the IDL function ``MODIS_GEO_INTERP_250``
+#
+#     :param nav_array: MODIS 1km latitude array or 1km longitude array
+#
+#     :returns: MODIS 250m latitude array or 250m longitude array
+#     """
+#     num_rows,num_cols = nav_array.shape
+#     num_scans = int(num_rows / ROWS_PER_SCAN)
+#
+#     # Make a resulting array that is the right size for the new resolution
+#     result_array = np.empty((num_rows * res_factor, num_cols * res_factor), dtype=np.float32)
+#     x = np.arange(res_factor * num_cols, dtype=np.float32) * 0.25
+#     y = np.arange(res_factor * ROWS_PER_SCAN, dtype=np.float32) * 0.25 - 0.375
+#     x,y = np.meshgrid(x,y)
+#     coordinates = np.array([y,x]) # Used by map_coordinates, major optimization
+#
+#     # Interpolate each scan, one at a time, otherwise the math doesn't work well
+#     for scan_idx in range(num_scans):
+#         # Calculate indexes
+#         j0 = ROWS_PER_SCAN              * scan_idx
+#         j1 = j0 + ROWS_PER_SCAN
+#         k0 = ROWS_PER_SCAN * res_factor * scan_idx
+#         k1 = k0 + ROWS_PER_SCAN * res_factor
+#
+#         # Use bilinear interpolation for all 250 meter pixels
+#         map_coordinates(nav_array[ j0:j1, : ], coordinates, output=result_array[ k0:k1, : ], order=1, mode='nearest')
+#
+#         # Use linear extrapolation for the first two 250 meter pixels along track
+#         m = (result_array[ k0 + 5, : ] - result_array[ k0 + 2, : ]) / (y[5,0] - y[2,0])
+#         b = result_array[ k0 + 5, : ] - m * y[5,0]
+#         result_array[ k0 + 0, : ] = m * y[0,0] + b
+#         result_array[ k0 + 1, : ] = m * y[1,0] + b
+#
+#         # Use linear extrapolation for the last  two 250 meter pixels along track
+#         m = (result_array[ k0 + 37, : ] - result_array[ k0 + 34, : ]) / (y[37,0] - y[34,0])
+#         b = result_array[ k0 + 37, : ] - m * y[37,0]
+#         result_array[ k0 + 38, : ] = m * y[38,0] + b
+#         result_array[ k0 + 39, : ] = m * y[39,0] + b
+#
+#     return result_array
+
+
+def modis_1km_to_250m(lon1, lat1):
+    """Interpolate MODIS geolocation from 1km to 250m resolution."""
+    return interpolate_geolocation_cartesian(lon1, lat1, res_factor=4)
+
+
+def modis_1km_to_500m(lon1, lat1):
+    """Interpolate MODIS geolocation from 1km to 500m resolution."""
+    return interpolate_geolocation_cartesian(lon1, lat1, res_factor=2)
+
+

--- a/geotiepoints/simple_modis_interpolator.py
+++ b/geotiepoints/simple_modis_interpolator.py
@@ -79,11 +79,12 @@ def interpolate_geolocation_cartesian(lon_array, lat_array, res_factor=4):
     z_in = EARTH_RADIUS * np.sin(lats_rad)
 
     # Create an array of indexes that we want our result to have
-    x = np.arange(res_factor * num_cols, dtype=np.float32) * (1./res_factor)
+    x = np.arange(res_factor * num_cols, dtype=np.float32) * (1. / res_factor)
     # 0.375 for 250m, 0.25 for 500m
-    y = np.arange(res_factor * ROWS_PER_SCAN, dtype=np.float32) * (1./res_factor) - (res_factor * (1./16) + (1./8))
-    x,y = np.meshgrid(x,y)
-    coordinates = np.array([y,x]) # Used by map_coordinates, major optimization
+    y = np.arange(res_factor * ROWS_PER_SCAN, dtype=np.float32) * (1. / res_factor) - (
+                res_factor * (1. / 16) + (1. / 8))
+    x, y = np.meshgrid(x, y)
+    coordinates = np.array([y, x])  # Used by map_coordinates, major optimization
 
     new_x = np.empty((num_rows * res_factor, num_cols * res_factor), dtype=np.float64)
     new_y = new_x.copy()
@@ -100,31 +101,31 @@ def interpolate_geolocation_cartesian(lon_array, lat_array, res_factor=4):
 
         for nav_array, result_array in nav_arrays:
             # Use bilinear interpolation for all 250 meter pixels
-            map_coordinates(nav_array[ j0:j1, : ], coordinates, output=result_array[ k0:k1, : ], order=1, mode='nearest')
+            map_coordinates(nav_array[j0:j1, :], coordinates, output=result_array[k0:k1, :], order=1, mode='nearest')
 
             if res_factor == 4:
                 # Use linear extrapolation for the first two 250 meter pixels along track
-                m = (result_array[ k0 + 5, : ] - result_array[ k0 + 2, : ]) / (y[5,0] - y[2,0])
-                b = result_array[ k0 + 5, : ] - m * y[5,0]
-                result_array[ k0 + 0, : ] = m * y[0,0] + b
-                result_array[ k0 + 1, : ] = m * y[1,0] + b
+                m = (result_array[k0 + 5, :] - result_array[k0 + 2, :]) / (y[5, 0] - y[2, 0])
+                b = result_array[k0 + 5, :] - m * y[5, 0]
+                result_array[k0 + 0, :] = m * y[0, 0] + b
+                result_array[k0 + 1, :] = m * y[1, 0] + b
 
                 # Use linear extrapolation for the last  two 250 meter pixels along track
-                m = (result_array[ k0 + 37, : ] - result_array[ k0 + 34, : ]) / (y[37,0] - y[34,0])
-                b = result_array[ k0 + 37, : ] - m * y[37,0]
-                result_array[ k0 + 38, : ] = m * y[38,0] + b
-                result_array[ k0 + 39, : ] = m * y[39,0] + b
+                m = (result_array[k0 + 37, :] - result_array[k0 + 34, :]) / (y[37, 0] - y[34, 0])
+                b = result_array[k0 + 37, :] - m * y[37, 0]
+                result_array[k0 + 38, :] = m * y[38, 0] + b
+                result_array[k0 + 39, :] = m * y[39, 0] + b
             else:
                 # 500m
                 # Use linear extrapolation for the first two 250 meter pixels along track
-                m = (result_array[ k0 + 2, : ] - result_array[ k0 + 1, : ]) / (y[2,0] - y[1,0])
-                b = result_array[ k0 + 2, : ] - m * y[2,0]
-                result_array[ k0 + 0, : ] = m * y[0,0] + b
+                m = (result_array[k0 + 2, :] - result_array[k0 + 1, :]) / (y[2, 0] - y[1, 0])
+                b = result_array[k0 + 2, :] - m * y[2, 0]
+                result_array[k0 + 0, :] = m * y[0, 0] + b
 
                 # Use linear extrapolation for the last  two 250 meter pixels along track
-                m = (result_array[ k0 + 18, : ] - result_array[ k0 + 17, : ]) / (y[18,0] - y[17,0])
-                b = result_array[ k0 + 18, : ] - m * y[18,0]
-                result_array[ k0 + 19, : ] = m * y[19,0] + b
+                m = (result_array[k0 + 18, :] - result_array[k0 + 17, :]) / (y[18, 0] - y[17, 0])
+                b = result_array[k0 + 18, :] - m * y[18, 0]
+                result_array[k0 + 19, :] = m * y[19, 0] + b
 
     # Convert from cartesian to lat/lon space
     new_lons = get_lons_from_cartesian(new_x, new_y)
@@ -186,5 +187,3 @@ def modis_1km_to_250m(lon1, lat1):
 def modis_1km_to_500m(lon1, lat1):
     """Interpolate MODIS geolocation from 1km to 500m resolution."""
     return interpolate_geolocation_cartesian(lon1, lat1, res_factor=2)
-
-

--- a/geotiepoints/simple_modis_interpolator.py
+++ b/geotiepoints/simple_modis_interpolator.py
@@ -174,30 +174,40 @@ def interpolate_geolocation_cartesian(lon_array, lat_array, res_factor=4):
 
             if res_factor == 4:
                 # Use linear extrapolation for the first two 250 meter pixels along track
-                m = (result_array[k0 + 5, :] - result_array[k0 + 2, :]) / (y[5, 0] - y[2, 0])
-                b = result_array[k0 + 5, :] - m * y[5, 0]
+                m, b = _calc_slope_offset_250(result_array, y, k0, 2)
                 result_array[k0 + 0, :] = m * y[0, 0] + b
                 result_array[k0 + 1, :] = m * y[1, 0] + b
 
                 # Use linear extrapolation for the last  two 250 meter pixels along track
-                m = (result_array[k0 + 37, :] - result_array[k0 + 34, :]) / (y[37, 0] - y[34, 0])
-                b = result_array[k0 + 37, :] - m * y[37, 0]
+                # m = (result_array[k0 + 37, :] - result_array[k0 + 34, :]) / (y[37, 0] - y[34, 0])
+                # b = result_array[k0 + 37, :] - m * y[37, 0]
+                m, b = _calc_slope_offset_250(result_array, y, k0, 34)
                 result_array[k0 + 38, :] = m * y[38, 0] + b
                 result_array[k0 + 39, :] = m * y[39, 0] + b
             else:
                 # 500m
                 # Use linear extrapolation for the first two 250 meter pixels along track
-                m = (result_array[k0 + 2, :] - result_array[k0 + 1, :]) / (y[2, 0] - y[1, 0])
-                b = result_array[k0 + 2, :] - m * y[2, 0]
+                m, b = _calc_slope_offset_500(result_array, y, k0, 1)
                 result_array[k0 + 0, :] = m * y[0, 0] + b
 
-                # Use linear extrapolation for the last  two 250 meter pixels along track
-                m = (result_array[k0 + 18, :] - result_array[k0 + 17, :]) / (y[18, 0] - y[17, 0])
-                b = result_array[k0 + 18, :] - m * y[18, 0]
+                # Use linear extrapolation for the last two 250 meter pixels along track
+                m, b = _calc_slope_offset_500(result_array, y, k0, 17)
                 result_array[k0 + 19, :] = m * y[19, 0] + b
 
     new_lons, new_lats = xyz2lonlat(new_x, new_y, new_z, low_lat_z=True)
     return new_lons.astype(lon_array.dtype), new_lats.astype(lon_array.dtype)
+
+
+def _calc_slope_offset_250(result_array, y, start_idx, offset):
+    m = (result_array[start_idx + offset + 3, :] - result_array[start_idx + offset, :]) / (y[offset + 3, 0] - y[offset, 0])
+    b = result_array[start_idx + offset + 3, :] - m * y[offset + 3, 0]
+    return m, b
+
+
+def _calc_slope_offset_500(result_array, y, start_idx, offset):
+    m = (result_array[start_idx + offset + 1, :] - result_array[start_idx + offset, :]) / (y[offset + 1, 0] - y[offset, 0])
+    b = result_array[start_idx + offset + 1, :] - m * y[offset + 1, 0]
+    return m, b
 
 
 def modis_1km_to_250m(lon1, lat1):

--- a/geotiepoints/simple_modis_interpolator.py
+++ b/geotiepoints/simple_modis_interpolator.py
@@ -199,13 +199,15 @@ def interpolate_geolocation_cartesian(lon_array, lat_array, res_factor=4):
 
 
 def _calc_slope_offset_250(result_array, y, start_idx, offset):
-    m = (result_array[start_idx + offset + 3, :] - result_array[start_idx + offset, :]) / (y[offset + 3, 0] - y[offset, 0])
+    m = (result_array[start_idx + offset + 3, :] - result_array[start_idx + offset, :]) / \
+        (y[offset + 3, 0] - y[offset, 0])
     b = result_array[start_idx + offset + 3, :] - m * y[offset + 3, 0]
     return m, b
 
 
 def _calc_slope_offset_500(result_array, y, start_idx, offset):
-    m = (result_array[start_idx + offset + 1, :] - result_array[start_idx + offset, :]) / (y[offset + 1, 0] - y[offset, 0])
+    m = (result_array[start_idx + offset + 1, :] - result_array[start_idx + offset, :]) / \
+        (y[offset + 1, 0] - y[offset, 0])
     b = result_array[start_idx + offset + 1, :] - m * y[offset + 1, 0]
     return m, b
 

--- a/geotiepoints/tests/test_simple_modis_interpolator.py
+++ b/geotiepoints/tests/test_simple_modis_interpolator.py
@@ -105,6 +105,15 @@ def test_basic_interp(input_func, exp_func, interp_func):
     assert not np.any(np.isnan(lats))
 
 
+def test_nonstandard_scan_size():
+    lon1, lat1 = _load_1km_lonlat_as_xarray_dask()
+    # remove 1 row from the end
+    lon1 = lon1[:-1]
+    lat1 = lat1[:-1]
+
+    pytest.raises(ValueError, modis_1km_to_250m, lon1, lat1)
+
+
 # def test_poles_datum(self):
 #     import xarray as xr
 #     h5f = h5py.File(FILENAME_DATA, 'r')

--- a/geotiepoints/tests/test_simple_modis_interpolator.py
+++ b/geotiepoints/tests/test_simple_modis_interpolator.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021 Python-geotiepoints developers
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Tests for simple MODIS interpolators."""
+
+import os
+import numpy as np
+import pytest
+import h5py
+import dask
+import dask.array as da
+import xarray as xr
+
+from geotiepoints.simple_modis_interpolator import modis_1km_to_250m, modis_1km_to_500m
+from .utils import CustomScheduler
+
+FILENAME_DATA = os.path.join(
+    os.path.dirname(__file__), '../../testdata/modis_test_data.h5')
+
+
+def _to_dask(arr):
+    return da.from_array(arr, chunks=4096)
+
+
+def _to_da(arr):
+    return xr.DataArray(_to_dask(arr), dims=['y', 'x'])
+
+
+def _load_h5_lonlat_vars(lon_var, lat_var):
+    h5f = h5py.File(FILENAME_DATA, 'r')
+    lon1 = h5f[lon_var]
+    lat1 = h5f[lat_var]
+    return lon1, lat1
+
+
+def _load_1km_lonlat_as_numpy():
+    lon1, lat1 = _load_h5_lonlat_vars('lon_1km', 'lat_1km')
+    return lon1[:], lat1[:]
+
+
+def _load_1km_lonlat_as_dask():
+    lon1, lat1 = _load_h5_lonlat_vars('lon_1km', 'lat_1km')
+    return _to_dask(lon1), _to_dask(lat1)
+
+
+def _load_1km_lonlat_as_xarray_dask():
+    lon1, lat1 = _load_h5_lonlat_vars('lon_1km', 'lat_1km')
+    return _to_da(lon1), _to_da(lat1)
+
+
+def _load_500m_lonlat_expected_as_xarray_dask():
+    h5f = h5py.File(FILENAME_DATA, 'r')
+    lon500 = _to_da(h5f['lon_500m'])
+    lat500 = _to_da(h5f['lat_500m'])
+    return lon500, lat500
+
+
+def _load_250m_lonlat_expected_as_xarray_dask():
+    h5f = h5py.File(FILENAME_DATA, 'r')
+    lon250 = _to_da(h5f['lon_250m'])
+    lat250 = _to_da(h5f['lat_250m'])
+    return lon250, lat250
+
+
+@pytest.mark.parametrize(
+    ("input_func", "exp_func", "interp_func"),
+    [
+        (_load_1km_lonlat_as_xarray_dask, _load_500m_lonlat_expected_as_xarray_dask, modis_1km_to_500m),
+        (_load_1km_lonlat_as_xarray_dask, _load_250m_lonlat_expected_as_xarray_dask, modis_1km_to_250m),
+        (_load_1km_lonlat_as_dask, _load_500m_lonlat_expected_as_xarray_dask, modis_1km_to_500m),
+        (_load_1km_lonlat_as_dask, _load_250m_lonlat_expected_as_xarray_dask, modis_1km_to_250m),
+        (_load_1km_lonlat_as_numpy, _load_500m_lonlat_expected_as_xarray_dask, modis_1km_to_500m),
+        (_load_1km_lonlat_as_numpy, _load_250m_lonlat_expected_as_xarray_dask, modis_1km_to_250m),
+    ]
+)
+def test_basic_interp(input_func, exp_func, interp_func):
+    lon1, lat1 = input_func()
+    lons_exp, lats_exp = exp_func()
+
+    # when working with dask arrays, we shouldn't compute anything
+    with dask.config.set(scheduler=CustomScheduler(0)):
+        lons, lats = interp_func(lon1, lat1)
+
+    if hasattr(lons, "compute"):
+        lons, lats = da.compute(lons, lats)
+    atol = 0.038  # 1e-2
+    rtol = 0
+    np.testing.assert_allclose(lons_exp, lons, atol=atol, rtol=rtol)
+    np.testing.assert_allclose(lats_exp, lats, atol=atol, rtol=rtol)
+    assert not np.any(np.isnan(lons))
+    assert not np.any(np.isnan(lats))
+
+
+# def test_poles_datum(self):
+#     import xarray as xr
+#     h5f = h5py.File(FILENAME_DATA, 'r')
+#     orig_lon = _to_da(h5f['lon_1km'])
+#     lon1 = orig_lon + 180
+#     lon1 = xr.where(lon1 > 180, lon1 - 360, lon1)
+#     lat1 = _to_da(h5f['lat_1km'])
+#     satz1 = _to_da(h5f['satz_1km'])
+#
+#     lat5 = lat1[2::5, 2::5]
+#     lon5 = lon1[2::5, 2::5]
+#
+#     satz5 = satz1[2::5, 2::5]
+#     lons, lats = modis_5km_to_1km(lon5, lat5, satz5)
+#     lons = lons + 180
+#     lons = xr.where(lons > 180, lons - 360, lons)
+#     np.testing.assert_allclose(orig_lon, lons, atol=1e-2)
+#     np.testing.assert_allclose(lat1, lats, atol=1e-2)

--- a/geotiepoints/tests/test_simple_modis_interpolator.py
+++ b/geotiepoints/tests/test_simple_modis_interpolator.py
@@ -96,6 +96,7 @@ def test_basic_interp(input_func, exp_func, interp_func):
 
     if hasattr(lons, "compute"):
         lons, lats = da.compute(lons, lats)
+    # our "truth" values are from the modisinterpolator results
     atol = 0.038  # 1e-2
     rtol = 0
     np.testing.assert_allclose(lons_exp, lons, atol=atol, rtol=rtol)

--- a/geotiepoints/tests/test_simple_modis_interpolator.py
+++ b/geotiepoints/tests/test_simple_modis_interpolator.py
@@ -112,23 +112,3 @@ def test_nonstandard_scan_size():
     lat1 = lat1[:-1]
 
     pytest.raises(ValueError, modis_1km_to_250m, lon1, lat1)
-
-
-# def test_poles_datum(self):
-#     import xarray as xr
-#     h5f = h5py.File(FILENAME_DATA, 'r')
-#     orig_lon = _to_da(h5f['lon_1km'])
-#     lon1 = orig_lon + 180
-#     lon1 = xr.where(lon1 > 180, lon1 - 360, lon1)
-#     lat1 = _to_da(h5f['lat_1km'])
-#     satz1 = _to_da(h5f['satz_1km'])
-#
-#     lat5 = lat1[2::5, 2::5]
-#     lon5 = lon1[2::5, 2::5]
-#
-#     satz5 = satz1[2::5, 2::5]
-#     lons, lats = modis_5km_to_1km(lon5, lat5, satz5)
-#     lons = lons + 180
-#     lons = xr.where(lons > 180, lons - 360, lons)
-#     np.testing.assert_allclose(orig_lon, lons, atol=1e-2)
-#     np.testing.assert_allclose(lat1, lats, atol=1e-2)

--- a/geotiepoints/tests/utils.py
+++ b/geotiepoints/tests/utils.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021 Python-geotiepoints developers
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Utilities for creating and checking tests."""
+
+
+class CustomScheduler(object):
+    """Scheduler raising an exception if data are computed too many times.
+
+    This only makes sense to include when working with dask-based arrays. To
+    use it::
+
+        with dask.config.set(scheduler=CustomScheduler(2)):
+            my_dask_arr.compute()  # allowed
+            my_dask_arr.compute()  # 2nd call, not allowed, fails
+
+    """
+
+    def __init__(self, max_computes=1):
+        """Set starting and maximum compute counts."""
+        self.max_computes = max_computes
+        self.total_computes = 0
+
+    def __call__(self, dsk, keys, **kwargs):
+        """Compute dask task and keep track of number of times we do so."""
+        import dask
+        self.total_computes += 1
+        if self.total_computes > self.max_computes:
+            raise RuntimeError("Too many dask computations were scheduled: "
+                               "{}".format(self.total_computes))
+        return dask.get(dsk, keys, **kwargs)

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,7 @@ release=1
 
 [flake8]
 max-line-length = 120
+ignore = D107
 
 [versioneer]
 VCS = git

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ import numpy as np
 from Cython.Build import cythonize
 
 requirements = ['numpy', 'scipy', 'pandas']
-test_requires = ['h5py', 'xarray', 'dask']
+test_requires = ['pytest', 'pytest-cov', 'h5py', 'xarray', 'dask']
 
 if sys.platform.startswith("win"):
     extra_compile_args = []
@@ -71,7 +71,6 @@ if __name__ == "__main__":
           cmdclass=cmdclass,
           install_requires=requirements,
           ext_modules=cythonize(EXTENSIONS),
-          test_suite='geotiepoints.tests.suite',
           tests_require=test_requires,
           zip_safe=False
           )


### PR DESCRIPTION
This ports the CSPP Polar2Grid MODIS lon/lat interpolation which only depends on longitude and latitude and is still fast.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [ ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
