### PR TITLE
Fix deprecated use of np.int

### DIFF
--- a/geotiepoints/multilinear.py
+++ b/geotiepoints/multilinear.py
@@ -62,7 +62,7 @@ class MultilinearInterpolator:
     def __init__(self, smin, smax, orders, values=None, dtype=np.float64):
         self.smin = np.array(smin, dtype=dtype)
         self.smax = np.array(smax, dtype=dtype)
-        self.orders = np.array(orders, dtype=np.int64)
+        self.orders = np.array(orders, dtype=np.int_)
         self.d = len(orders)
         self.dtype = dtype
         if values is not None:

--- a/geotiepoints/multilinear.py
+++ b/geotiepoints/multilinear.py
@@ -62,7 +62,7 @@ class MultilinearInterpolator:
     def __init__(self, smin, smax, orders, values=None, dtype=np.float64):
         self.smin = np.array(smin, dtype=dtype)
         self.smax = np.array(smax, dtype=dtype)
-        self.orders = np.array(orders, dtype=np.int)
+        self.orders = np.array(orders, dtype=np.int64)
         self.d = len(orders)
         self.dtype = dtype
         if values is not None:


### PR DESCRIPTION
Simple fix to get rid of a deprecation warning:

```
/home/lahtinep/mambaforge/envs/pytroll/lib/python3.9/site-packages/geotiepoints/multilinear.py:65: DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
  self.orders = np.array(orders, dtype=np.int)
```

 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
