### PR TITLE
Rewrite modis angle-based interpolation in cython

### DIFF
--- a/geotiepoints/_modis_interpolator.pyx
+++ b/geotiepoints/_modis_interpolator.pyx
@@ -331,8 +331,6 @@ cdef class Interpolator:
         lonlat2xyz(lon1_c, lat1_c, xyz_c_view)
         lonlat2xyz(lon1_d, lat1_d, xyz_d_view)
 
-        cdef np.ndarray[floating, ndim=3] data
-        # cdef np.ndarray[floating, ndim=3] data_a, data_b, data_c, data_d
         cdef np.ndarray[floating, ndim=2] data_a_2d, data_b_2d, data_c_2d, data_d_2d
         cdef np.ndarray[floating, ndim=3] comp_arr_2d = np.empty((a_scan.shape[0], a_scan.shape[1], 3), dtype=lon1.dtype)
         cdef floating[:, :, ::1] xyz_comp_view = comp_arr_2d
@@ -341,8 +339,8 @@ cdef class Interpolator:
         cdef floating scan1_tmp, scan2_tmp, atrack1, ascan1
         cdef floating[:, ::1] data_a_2d_view, data_b_2d_view, data_c_2d_view, data_d_2d_view
         cdef np.ndarray[floating, ndim=3] comp_a, comp_b, comp_c, comp_d
-        print(a_scan.shape[0], a_scan.shape[1], a_track.shape[0], a_track.shape[1], comp_arr_2d.shape[0], comp_arr_2d.shape[1], comp_arr_2d.shape[2])
-        print(xyz_a.shape[0], xyz_a.shape[1], xyz_a.shape[2], xyz_a.shape[3])
+        cdef floating[:, ::1] a_track_view = a_track
+        cdef floating[:, ::1] a_scan_view = a_scan
         for k in range(3):  # xyz
             # data_a_2d = self._expand_tiepoint_array(xyz_a[:, :, :, k])
             # data_b_2d = self._expand_tiepoint_array(xyz_b[:, :, :, k])
@@ -360,26 +358,14 @@ cdef class Interpolator:
             data_b_2d_view = data_b_2d
             data_c_2d_view = data_c_2d
             data_d_2d_view = data_d_2d
-            print(data_a_2d.shape[0], data_a_2d.shape[1], data_b_2d.shape[0], data_b_2d.shape[1])
-            # TODO: assign views
             for i in range(a_scan.shape[0]):
                 for j in range(a_scan.shape[1]):
-                    atrack1 = a_track[i, j]
-                    ascan1 = a_scan[i, j]
+                    atrack1 = a_track_view[i, j]
+                    ascan1 = a_scan_view[i, j]
                     scan1_tmp = (1 - ascan1) * data_a_2d_view[i, j] + ascan1 * data_b_2d_view[i, j]
                     scan2_tmp = (1 - ascan1) * data_d_2d_view[i, j] + ascan1 * data_c_2d_view[i, j]
                     xyz_comp_view[i, j, k] = (1 - atrack1) * scan1_tmp + atrack1 * scan2_tmp
 
-        # for xyz_comp_a, xyz_comp_b, xyz_comp_c, xyz_comp_d  in zip(xyz_a, xyz_b, xyz_c, xyz_d):
-        #     data_a_2d = self._expand_tiepoint_array(xyz_comp_a)
-        #     data_b_2d = self._expand_tiepoint_array(xyz_comp_b)
-        #     data_c_2d = self._expand_tiepoint_array(xyz_comp_c)
-        #     data_d_2d = self._expand_tiepoint_array(xyz_comp_d)
-        #
-        #     data_1 = (1 - a_scan) * data_a_2d + a_scan * data_b_2d
-        #     data_2 = (1 - a_scan) * data_d_2d + a_scan * data_c_2d
-        #     comp_arr_2d = (1 - a_track) * data_1 + a_track * data_2
-        #     res.append(comp_arr_2d)
         cdef np.ndarray[floating, ndim=2] new_lons = np.empty((a_scan.shape[0], a_scan.shape[1]), dtype=lon1.dtype)
         cdef np.ndarray[floating, ndim=2] new_lats = np.empty((a_scan.shape[0], a_scan.shape[1]), dtype=lon1.dtype)
         cdef floating[:, ::1] new_lons_view = new_lons

--- a/geotiepoints/_modis_interpolator.pyx
+++ b/geotiepoints/_modis_interpolator.pyx
@@ -11,10 +11,6 @@ ctypedef fused floating:
     np.float64_t
 
 DEF EARTH_RADIUS = 6370997.0
-# cdef np.float32_t R = 6371.0
-# # Aqua scan width and altitude in km
-# cdef np.float32_t scan_width = 10.00017
-# cdef np.float32_t H = 705.0
 DEF R = 6371.0
 # Aqua scan width and altitude in km
 DEF scan_width = 10.00017
@@ -274,7 +270,6 @@ cdef class Interpolator:
         cdef unsigned int scans = satz1.shape[0] // self._coarse_scan_length
         # reshape to (num scans, rows per scan, columns per scan)
         cdef floating[:, :, ::1] satz1_3d = satz1.reshape((-1, self._coarse_scan_length, self._coarse_scan_width))
-
         cdef floating[:, :, ::1] satz_a_view = _get_upper_left_corner(satz1_3d)
         cdef floating[:, :, ::1] satz_b_view = _get_upper_right_corner(satz1_3d)
         cdef np.ndarray[floating, ndim=3] c_exp = np.empty(
@@ -316,13 +311,9 @@ cdef class Interpolator:
                                       np.ndarray[floating, ndim=2] lat1,
                                       np.ndarray[floating, ndim=2] a_track,
                                       np.ndarray[floating, ndim=2] a_scan):
-        res = []
-        cdef np.ndarray[floating, ndim=3] lon1_3d, lat1_3d
-        lon1_3d = lon1.reshape((-1, self._coarse_scan_length, self._coarse_scan_width))
-        lat1_3d = lat1.reshape((-1, self._coarse_scan_length, self._coarse_scan_width))
         cdef floating[:, :, ::1] lon1_3d_view, lat1_3d_view
-        lon1_3d_view = lon1_3d
-        lat1_3d_view = lat1_3d
+        lon1_3d_view = lon1.reshape((-1, self._coarse_scan_length, self._coarse_scan_width))
+        lat1_3d_view = lat1.reshape((-1, self._coarse_scan_length, self._coarse_scan_width))
         cdef floating[:, :, ::1] lon1_a, lon1_b, lon1_c, lon1_d, lat1_a, lat1_b, lat1_c, lat1_d
         lon1_a = _get_upper_left_corner(lon1_3d_view)
         lon1_b = _get_upper_right_corner(lon1_3d_view)

--- a/geotiepoints/_modis_interpolator.pyx
+++ b/geotiepoints/_modis_interpolator.pyx
@@ -297,16 +297,16 @@ cdef class Interpolator:
 
     cdef np.ndarray[floating, ndim=2] _expand_tiepoint_array_5km(self, np.ndarray[floating, ndim=3] arr):
         arr = np.repeat(arr, self._fine_scan_length * 2, axis=1)
-        arr = np.repeat(arr.reshape((-1, self._coarse_scan_width - 1)), self._fine_pixels_per_coarse_pixel, axis=1)
+        cdef np.ndarray[floating, ndim=2] arr_2d = np.repeat(arr.reshape((-1, self._coarse_scan_width - 1)), self._fine_pixels_per_coarse_pixel, axis=1)
         factor = self._fine_pixels_per_coarse_pixel // self._coarse_pixels_per_1km
         if self._coarse_scan_width == 271:
-            return np.hstack((arr[:, :2 * factor], arr, arr[:, -2 * factor:]))
+            return np.hstack((arr_2d[:, :2 * factor], arr_2d, arr_2d[:, -2 * factor:]))
         else:
             return np.hstack(
                 (
-                    arr[:, :2 * factor],
-                    arr,
-                    arr[:, -self._fine_pixels_per_coarse_pixel:],
-                    arr[:, -2 * factor:],
+                    arr_2d[:, :2 * factor],
+                    arr_2d,
+                    arr_2d[:, -self._fine_pixels_per_coarse_pixel:],
+                    arr_2d[:, -2 * factor:],
                 )
             )

--- a/geotiepoints/_modis_interpolator.pyx
+++ b/geotiepoints/_modis_interpolator.pyx
@@ -35,8 +35,8 @@ cdef void lonlat2xyz(
     for i in range(lons.shape[0]):
         for j in range(lons.shape[1]):
             for k in range(lons.shape[2]):
-                lon_rad = _deg2rad64(lons[i, j, k])
-                lat_rad = _deg2rad64(lats[i, j, k])
+                lon_rad = _deg2rad(lons[i, j, k])
+                lat_rad = _deg2rad(lats[i, j, k])
                 xyz[i, j, k, 0] = EARTH_RADIUS * cos(lat_rad) * cos(lon_rad)
                 xyz[i, j, k, 1] = EARTH_RADIUS * cos(lat_rad) * sin(lon_rad)
                 xyz[i, j, k, 2] = EARTH_RADIUS * sin(lat_rad)
@@ -60,14 +60,14 @@ cdef void xyz2lonlat(
             x = <np.float64_t>xyz[i, j, 0]
             y = <np.float64_t>xyz[i, j, 1]
             z = <np.float64_t>xyz[i, j, 2]
-            lons[i, j] = _rad2deg64(acos(x / sqrt(x ** 2 + y ** 2))) * _sign(y)
+            lons[i, j] = _rad2deg(acos(x / sqrt(x ** 2 + y ** 2))) * _sign(y)
             # if we are at low latitudes - small z, then get the
             # latitudes only from z. If we are at high latitudes (close to the poles)
             # then derive the latitude using x and y:
             if low_lat_z and (z < thr * EARTH_RADIUS) and (z > -1.0 * thr * EARTH_RADIUS):
-                lats[i, j] = 90 - _rad2deg64(acos(z / EARTH_RADIUS))
+                lats[i, j] = 90 - _rad2deg(acos(z / EARTH_RADIUS))
             else:
-                lats[i, j] = _sign(z) * (90 - _rad2deg64(asin(sqrt(x ** 2 + y ** 2) / EARTH_RADIUS)))
+                lats[i, j] = _sign(z) * (90 - _rad2deg(asin(sqrt(x ** 2 + y ** 2) / EARTH_RADIUS)))
 
 
 cdef inline int _sign(floating x) nogil:
@@ -79,14 +79,6 @@ cdef inline floating _rad2deg(floating x) nogil:
 
 
 cdef inline floating _deg2rad(floating x) nogil:
-    return x * (M_PI / 180.0)
-
-
-cdef inline np.float64_t _rad2deg64(np.float64_t x) nogil:
-    return x * (180.0 / M_PI)
-
-
-cdef inline np.float64_t _deg2rad64(np.float64_t x) nogil:
     return x * (M_PI / 180.0)
 
 

--- a/geotiepoints/_modis_interpolator.pyx
+++ b/geotiepoints/_modis_interpolator.pyx
@@ -300,20 +300,20 @@ cdef class Interpolator:
             floating[::1] x_view,
             floating[::1] y_view,
     ) nogil:
-        cdef int half_scan_length = self._fine_pixels_per_coarse_pixel // 2
         cdef unsigned int scan_idx
         cdef int i
         cdef int fine_idx
+        cdef int half_scan_length = self._fine_pixels_per_coarse_pixel // 2
         cdef unsigned int fine_pixels_per_scan = self._coarse_scan_length * self._fine_pixels_per_coarse_pixel
         for scan_idx in range(scans):
             for i in range(fine_pixels_per_scan):
                 fine_idx = scan_idx * fine_pixels_per_scan + i
                 if i < half_scan_length:
-                    y_view[fine_idx] = (-half_scan_length + 0.5) - i
-                elif i > fine_pixels_per_scan - half_scan_length:
-                    y_view[fine_idx] = (self._fine_pixels_per_coarse_pixel + 0.5) + (fine_pixels_per_scan - i)
+                    y_view[fine_idx] = -half_scan_length + 0.5 + i
+                elif i >= fine_pixels_per_scan - half_scan_length:
+                    y_view[fine_idx] = (self._fine_pixels_per_coarse_pixel + 0.5) + (half_scan_length - (fine_pixels_per_scan - i))
                 else:
-                    y_view[fine_idx] = (i % self._fine_pixels_per_coarse_pixel) + 0.5
+                    y_view[fine_idx] = ((i + half_scan_length) % self._fine_pixels_per_coarse_pixel) + 0.5
 
         for i in range(self._fine_pixels_per_coarse_pixel):
             x_view[(self._fine_scan_width - self._fine_pixels_per_coarse_pixel) + i] = self._fine_pixels_per_coarse_pixel + i

--- a/geotiepoints/_modis_interpolator.pyx
+++ b/geotiepoints/_modis_interpolator.pyx
@@ -1,0 +1,290 @@
+from libc.math cimport fmin, fmax, floor
+cimport cython
+from cython.parallel import prange,parallel
+from .simple_modis_interpolator import scanline_mapblocks
+
+cimport numpy as np
+import numpy as np
+
+# ctypedef fused floating:
+#     float
+#     double
+
+ctypedef fused floating:
+    np.float32_t
+    np.float64_t
+
+EARTH_RADIUS = 6370997.0
+R = 6371.0
+# Aqua scan width and altitude in km
+scan_width = 10.00017
+H = 705.0
+
+
+def lonlat2xyz(
+        lons, lats,
+        # floating[:, :] lons, floating[:, :] lats,
+        floating radius=EARTH_RADIUS):
+    """Convert lons and lats to cartesian coordinates."""
+    lons_rad = np.deg2rad(lons)
+    lats_rad = np.deg2rad(lats)
+    x_coords = radius * np.cos(lats_rad) * np.cos(lons_rad)
+    y_coords = radius * np.cos(lats_rad) * np.sin(lons_rad)
+    z_coords = radius * np.sin(lats_rad)
+    return x_coords, y_coords, z_coords
+
+
+def xyz2lonlat(
+        # floating[:, :] x__,
+        # floating[:, :] y__,
+        # floating[:, :] z__,
+        # np.ndarray[floating, ndim=2] x__,
+        # np.ndarray[floating, ndim=2] y__,
+        # np.ndarray[floating, ndim=2] z__,
+        x__,
+        y__,
+        z__,
+        floating radius=EARTH_RADIUS,
+        floating thr=0.8,
+        bint low_lat_z=True):
+    """Get longitudes from cartesian coordinates."""
+    lons = np.rad2deg(np.arccos(x__ / np.sqrt(x__ ** 2 + y__ ** 2))) * np.sign(y__)
+    lats = np.sign(z__) * (90 - np.rad2deg(np.arcsin(np.sqrt(x__ ** 2 + y__ ** 2) / radius)))
+    if low_lat_z:
+        # if we are at low latitudes - small z, then get the
+        # latitudes only from z. If we are at high latitudes (close to the poles)
+        # then derive the latitude using x and y:
+        lat_mask_cond = np.logical_and(
+            np.less(z__, thr * radius),
+            np.greater(z__, -1. * thr * radius))
+        lat_z_only = 90 - np.rad2deg(np.arccos(z__ / radius))
+        lats = np.where(lat_mask_cond, lat_z_only, lats)
+
+    return lons, lats
+
+
+@scanline_mapblocks
+def interpolate(
+        np.ndarray[floating, ndim=2] lon1,
+        np.ndarray[floating, ndim=2] lat1,
+        np.ndarray[floating, ndim=2] satz1,
+        unsigned int coarse_resolution=0,
+        unsigned int fine_resolution=0,
+        unsigned int coarse_scan_width=0,
+):
+    """Helper function to interpolate scan-aligned arrays.
+
+    This function's decorator runs this function for each dask block/chunk of
+    scans. The arrays are scan-aligned meaning they are an even number of scans
+    (N rows per scan) and contain the entire scan width.
+
+    """
+    interp = Interpolator(coarse_resolution, fine_resolution, coarse_scan_width=coarse_scan_width or 0)
+    return interp.interpolate(lon1, lat1, satz1)
+
+
+def _compute_phi(zeta):
+    return np.arcsin(R * np.sin(zeta) / (R + H))
+
+
+def _compute_theta(zeta, phi):
+    return zeta - phi
+
+
+def _compute_zeta(phi):
+    return np.arcsin((R + H) * np.sin(phi) / R)
+
+
+def _compute_expansion_alignment(satz_a, satz_b):
+    """All angles in radians."""
+    zeta_a = satz_a
+    zeta_b = satz_b
+
+    phi_a = _compute_phi(zeta_a)
+    phi_b = _compute_phi(zeta_b)
+    theta_a = _compute_theta(zeta_a, phi_a)
+    theta_b = _compute_theta(zeta_b, phi_b)
+    phi = (phi_a + phi_b) / 2
+    zeta = _compute_zeta(phi)
+    theta = _compute_theta(zeta, phi)
+    # Workaround for tiepoints symetrical about the subsatellite-track
+    denominator = np.where(theta_a == theta_b, theta_a * 2, theta_a - theta_b)
+
+    c_expansion = 4 * (((theta_a + theta_b) / 2 - theta) / denominator)
+
+    sin_beta_2 = scan_width / (2 * H)
+
+    d = ((R + H) / R * np.cos(phi) - np.cos(zeta)) * sin_beta_2
+    e = np.cos(zeta) - np.sqrt(np.cos(zeta) ** 2 - d ** 2)
+
+    c_alignment = 4 * e * np.sin(zeta) / denominator
+
+    return c_expansion, c_alignment
+
+
+def _get_corners(arr):
+    arr_a = arr[:, :-1, :-1]
+    arr_b = arr[:, :-1, 1:]
+    arr_c = arr[:, 1:, 1:]
+    arr_d = arr[:, 1:, :-1]
+    return arr_a, arr_b, arr_c, arr_d
+
+
+cdef class Interpolator:
+    """Helper class for MODIS interpolation.
+
+    Not intended for public use. Use ``modis_X_to_Y`` functions instead.
+
+    """
+
+    cdef int _coarse_scan_length
+    cdef int _coarse_scan_width
+    cdef int _coarse_pixels_per_1km
+    cdef int _fine_pixels_per_coarse_pixel
+    cdef int _fine_scan_width
+    cdef int _fine_scan_length
+    cdef int _coarse_resolution
+    cdef int _fine_resolution
+    cdef _get_coords
+    cdef _expand_tiepoint_array
+
+    def __init__(self, unsigned int coarse_resolution, unsigned int fine_resolution, unsigned int coarse_scan_width=0):
+        if coarse_resolution == 1000:
+            coarse_scan_length = 10
+            coarse_scan_width = 1354
+            self._get_coords = self._get_coords_1km
+            self._expand_tiepoint_array = self._expand_tiepoint_array_1km
+        elif coarse_resolution == 5000:
+            coarse_scan_length = 2
+            self._get_coords = self._get_coords_5km
+            self._expand_tiepoint_array = self._expand_tiepoint_array_5km
+            if coarse_scan_width == 0:
+                coarse_scan_width = 271
+            else:
+                coarse_scan_width = coarse_scan_width
+        self._coarse_scan_length = coarse_scan_length
+        self._coarse_scan_width = coarse_scan_width
+        self._coarse_pixels_per_1km = coarse_resolution // 1000
+
+        fine_pixels_per_1km = {
+            250: 4,
+            500: 2,
+            1000: 1,
+        }[fine_resolution]
+        self._fine_pixels_per_coarse_pixel = fine_pixels_per_1km * self._coarse_pixels_per_1km
+        self._fine_scan_width = 1354 * fine_pixels_per_1km
+        self._fine_scan_length = fine_pixels_per_1km * 10 // coarse_scan_length
+        self._coarse_resolution = coarse_resolution
+        self._fine_resolution = fine_resolution
+
+    @cython.boundscheck(False)
+    @cython.cdivision(True)
+    @cython.wraparound(False)
+    cdef interpolate(
+            self,
+            np.ndarray[floating, ndim=2] lon1,
+            np.ndarray[floating, ndim=2] lat1,
+            np.ndarray[floating, ndim=2] satz1_):
+        """Interpolate MODIS geolocation from 'coarse_resolution' to 'fine_resolution'."""
+        scans = satz1_.shape[0] // self._coarse_scan_length
+        # reshape to (num scans, rows per scan, columns per scan)
+        satz1 = satz1_.reshape((-1, self._coarse_scan_length, self._coarse_scan_width))
+        # cdef floating [:, :, :] satz1 = satz1_.reshape((-1, self._coarse_scan_length, self._coarse_scan_width))
+
+        satz_a, satz_b = _get_corners(np.deg2rad(satz1))[:2]
+        c_exp, c_ali = _compute_expansion_alignment(satz_a, satz_b)
+
+        x, y = self._get_coords(scans)
+        i_rs, i_rt = np.meshgrid(x, y)
+
+        p_os = 0
+        p_ot = 0
+        s_s = (p_os + i_rs) * 1.0 / self._fine_pixels_per_coarse_pixel
+        s_t = (p_ot + i_rt) * 1.0 / self._fine_scan_length
+
+        c_exp_full = self._expand_tiepoint_array(c_exp)
+        c_ali_full = self._expand_tiepoint_array(c_ali)
+
+        a_track = s_t
+        a_scan = s_s + s_s * (1 - s_s) * c_exp_full + s_t * (1 - s_t) * c_ali_full
+
+        res = []
+        datasets = lonlat2xyz(lon1, lat1)
+        for data in datasets:
+            data = data.reshape((-1, self._coarse_scan_length, self._coarse_scan_width))
+            data_a, data_b, data_c, data_d = _get_corners(data)
+            data_a = self._expand_tiepoint_array(data_a)
+            data_b = self._expand_tiepoint_array(data_b)
+            data_c = self._expand_tiepoint_array(data_c)
+            data_d = self._expand_tiepoint_array(data_d)
+
+            data_1 = (1 - a_scan) * data_a + a_scan * data_b
+            data_2 = (1 - a_scan) * data_d + a_scan * data_c
+            data = (1 - a_track) * data_1 + a_track * data_2
+
+            res.append(data)
+        new_lons, new_lats = xyz2lonlat(*res)
+        return new_lons.astype(lon1.dtype), new_lats.astype(lat1.dtype)
+
+    def _get_coords_1km(self, unsigned int scans):
+        cdef np.ndarray[np.float32_t, ndim=1] y = (np.arange((self._coarse_scan_length + 1) * self._fine_scan_length, dtype=np.float32) % self._fine_scan_length) + 0.5
+        cdef int half_scan_length = self._fine_scan_length // 2
+        cdef np.ndarray[np.float32_t, ndim=1] y2 = y[half_scan_length:-half_scan_length]
+        y2[:half_scan_length] = np.arange(-self._fine_scan_length / 2 + 0.5, 0)
+        y2[-half_scan_length:] = np.arange(self._fine_scan_length + 0.5, self._fine_scan_length * 3 / 2)
+        cdef np.ndarray[np.float32_t, ndim=1] y3 = np.tile(y2, scans)
+
+        cdef np.ndarray[np.float32_t, ndim=1] x = np.arange(self._fine_scan_width, dtype=np.float32) % self._fine_pixels_per_coarse_pixel
+        x[-self._fine_pixels_per_coarse_pixel:] = np.arange(
+            self._fine_pixels_per_coarse_pixel,
+            self._fine_pixels_per_coarse_pixel * 2)
+        return x, y3
+
+    # def _get_coords_5km(self, unsigned int scans):
+    def _get_coords_5km(self, scans):
+        y = np.arange(self._fine_scan_length * self._coarse_scan_length) - 2
+        y = np.tile(y, scans)
+
+        x = (np.arange(self._fine_scan_width) - 2) % self._fine_pixels_per_coarse_pixel
+        x[0] = -2
+        x[1] = -1
+        if self._coarse_scan_width == 271:
+            x[-2] = 5
+            x[-1] = 6
+        elif self._coarse_scan_width == 270:
+            x[-7] = 5
+            x[-6] = 6
+            x[-5] = 7
+            x[-4] = 8
+            x[-3] = 9
+            x[-2] = 10
+            x[-1] = 11
+        else:
+            raise NotImplementedError(
+                "Can't interpolate if 5km tiepoints have less than 270 columns."
+            )
+        return x, y
+
+    def _expand_tiepoint_array_1km(self, arr):
+        arr = np.repeat(arr, self._fine_scan_length, axis=1)
+        arr = np.concatenate(
+            (arr[:, :self._fine_scan_length // 2, :], arr, arr[:, -(self._fine_scan_length // 2):, :]), axis=1
+        )
+        arr = np.repeat(arr.reshape((-1, self._coarse_scan_width - 1)), self._fine_pixels_per_coarse_pixel, axis=1)
+        return np.hstack((arr, arr[:, -self._fine_pixels_per_coarse_pixel:]))
+
+    def _expand_tiepoint_array_5km(self, arr):
+        arr = np.repeat(arr, self._fine_scan_length * 2, axis=1)
+        arr = np.repeat(arr.reshape((-1, self._coarse_scan_width - 1)), self._fine_pixels_per_coarse_pixel, axis=1)
+        factor = self._fine_pixels_per_coarse_pixel // self._coarse_pixels_per_1km
+        if self._coarse_scan_width == 271:
+            return np.hstack((arr[:, :2 * factor], arr, arr[:, -2 * factor:]))
+        else:
+            return np.hstack(
+                (
+                    arr[:, :2 * factor],
+                    arr,
+                    arr[:, -self._fine_pixels_per_coarse_pixel:],
+                    arr[:, -2 * factor:],
+                )
+            )

--- a/geotiepoints/_modis_interpolator.pyx
+++ b/geotiepoints/_modis_interpolator.pyx
@@ -496,82 +496,82 @@ cdef class Interpolator:
     @cython.boundscheck(False)
     @cython.cdivision(True)
     @cython.wraparound(False)
-    cdef void _expand_tiepoint_array_1km(self, floating[:, :, :] arr, floating[:, ::1] arr_2d_view) nogil:
+    cdef void _expand_tiepoint_array_1km(self, floating[:, :, :] input_arr, floating[:, ::1] expanded_arr) nogil:
         # TODO: Replace shape multiplication with self._fine_pixel_length and self._fine_pixel_width
         cdef floating tiepoint_value
         cdef Py_ssize_t scan_idx, row_idx, col_idx, length_repeat_cycle, width_repeat_cycle, half_coarse_pixel_fine_offset, scan_offset, row_offset, col_offset
         half_coarse_pixel_fine_offset = self._fine_pixels_per_coarse_pixel // 2
-        for scan_idx in range(arr.shape[0]):
+        for scan_idx in range(input_arr.shape[0]):
             scan_offset = scan_idx * self._fine_pixels_per_coarse_pixel * self._coarse_scan_length
-            for row_idx in range(arr.shape[1]):
+            for row_idx in range(input_arr.shape[1]):
                 row_offset = row_idx * self._fine_pixels_per_coarse_pixel
-                for col_idx in range(arr.shape[2]):
+                for col_idx in range(input_arr.shape[2]):
                     col_offset = col_idx * self._fine_pixels_per_coarse_pixel
-                    tiepoint_value = arr[scan_idx, row_idx, col_idx]
+                    tiepoint_value = input_arr[scan_idx, row_idx, col_idx]
                     for length_repeat_cycle in range(self._fine_pixels_per_coarse_pixel):
                         for width_repeat_cycle in range(self._fine_pixels_per_coarse_pixel):
                             # main "center" scan portion
-                            arr_2d_view[scan_offset + row_offset + length_repeat_cycle + half_coarse_pixel_fine_offset,
+                            expanded_arr[scan_offset + row_offset + length_repeat_cycle + half_coarse_pixel_fine_offset,
                                         col_offset + width_repeat_cycle] = tiepoint_value
                             if row_offset < half_coarse_pixel_fine_offset:
                                 # copy of top half of the scan
-                                arr_2d_view[scan_offset + row_offset + length_repeat_cycle,
+                                expanded_arr[scan_offset + row_offset + length_repeat_cycle,
                                             col_offset + width_repeat_cycle] = tiepoint_value
-                            elif row_offset >= (((arr.shape[1] - 1) * self._fine_pixels_per_coarse_pixel) - half_coarse_pixel_fine_offset):
+                            elif row_offset >= (((input_arr.shape[1] - 1) * self._fine_pixels_per_coarse_pixel) - half_coarse_pixel_fine_offset):
                                 # copy of bottom half of the scan
                                 # TODO: Clean this up
-                                arr_2d_view[scan_offset + row_offset + length_repeat_cycle + self._fine_pixels_per_coarse_pixel,
+                                expanded_arr[scan_offset + row_offset + length_repeat_cycle + self._fine_pixels_per_coarse_pixel,
                                             col_offset + width_repeat_cycle] = tiepoint_value
-                            if col_idx == arr.shape[2] - 1:
+                            if col_idx == input_arr.shape[2] - 1:
                                 # there is one less coarse column than needed by the fine resolution
                                 # copy last coarse column as the last fine coarse column
                                 # this last coarse column will be both the second to last and the last
                                 # fine resolution columns
-                                arr_2d_view[scan_offset + row_offset + length_repeat_cycle + half_coarse_pixel_fine_offset,
+                                expanded_arr[scan_offset + row_offset + length_repeat_cycle + half_coarse_pixel_fine_offset,
                                             col_offset + self._fine_pixels_per_coarse_pixel + width_repeat_cycle] = tiepoint_value
                                 # also need the top and bottom half copies
                                 if row_offset < half_coarse_pixel_fine_offset:
                                     # copy of top half of the scan
-                                    arr_2d_view[scan_offset + row_offset + length_repeat_cycle,
+                                    expanded_arr[scan_offset + row_offset + length_repeat_cycle,
                                                 col_offset + self._fine_pixels_per_coarse_pixel + width_repeat_cycle] = tiepoint_value
-                                elif row_offset >= (((arr.shape[1] - 1) * self._fine_pixels_per_coarse_pixel) - half_coarse_pixel_fine_offset):
+                                elif row_offset >= (((input_arr.shape[1] - 1) * self._fine_pixels_per_coarse_pixel) - half_coarse_pixel_fine_offset):
                                     # TODO: Clean this up
                                     # copy of bottom half of the scan
-                                    arr_2d_view[scan_offset + row_offset + length_repeat_cycle + self._fine_pixels_per_coarse_pixel,
+                                    expanded_arr[scan_offset + row_offset + length_repeat_cycle + self._fine_pixels_per_coarse_pixel,
                                                 col_offset + self._fine_pixels_per_coarse_pixel + width_repeat_cycle] = tiepoint_value
 
     @cython.boundscheck(False)
     @cython.cdivision(True)
     @cython.wraparound(False)
-    cdef void _expand_tiepoint_array_5km(self, floating[:, :, :] arr, floating[:, ::1] arr_2d_view) nogil:
+    cdef void _expand_tiepoint_array_5km(self, floating[:, :, :] input_arr, floating[:, ::1] expanded_arr) nogil:
         cdef floating tiepoint_value
         cdef Py_ssize_t scan_idx, row_idx, col_idx, length_repeat_cycle, width_repeat_cycle, scan_offset, row_offset, col_offset
         # partial rows/columns to repeat: 5km->1km => 2, 5km->500m => 4, 5km->250m => 8
         cdef Py_ssize_t factor = self._fine_pixels_per_coarse_pixel // self._coarse_pixels_per_1km * 2
-        for scan_idx in range(arr.shape[0]):
+        for scan_idx in range(input_arr.shape[0]):
             scan_offset = scan_idx * self._fine_pixels_per_coarse_pixel * self._coarse_scan_length
-            for row_idx in range(arr.shape[1]):
+            for row_idx in range(input_arr.shape[1]):
                 row_offset = row_idx * self._fine_pixels_per_coarse_pixel * 2
-                for col_idx in range(arr.shape[2]):
+                for col_idx in range(input_arr.shape[2]):
                     col_offset = col_idx * self._fine_pixels_per_coarse_pixel
-                    tiepoint_value = arr[scan_idx, row_idx, col_idx]
+                    tiepoint_value = input_arr[scan_idx, row_idx, col_idx]
                     for length_repeat_cycle in range(self._fine_pixels_per_coarse_pixel * 2):
                         for width_repeat_cycle in range(self._fine_pixels_per_coarse_pixel):
                             # main "center" scan portion
-                            arr_2d_view[scan_offset + row_offset + length_repeat_cycle,
+                            expanded_arr[scan_offset + row_offset + length_repeat_cycle,
                                         col_offset + width_repeat_cycle + factor] = tiepoint_value
                             if (col_offset + width_repeat_cycle) < factor:
-                                arr_2d_view[scan_offset + row_offset + length_repeat_cycle,
+                                expanded_arr[scan_offset + row_offset + length_repeat_cycle,
                                             col_offset + width_repeat_cycle] = tiepoint_value
-                            if self._coarse_scan_width == 270 and (col_idx >= arr.shape[2] - 1):
+                            if self._coarse_scan_width == 270 and (col_idx >= input_arr.shape[2] - 1):
                                 # need an extra coarse column copied over
-                                arr_2d_view[scan_offset + row_offset + length_repeat_cycle,
+                                expanded_arr[scan_offset + row_offset + length_repeat_cycle,
                                             col_offset + factor + width_repeat_cycle + self._fine_pixels_per_coarse_pixel] = tiepoint_value
-                            if self._coarse_scan_width == 270 and (arr_2d_view.shape[1] - (col_offset + width_repeat_cycle + factor) <= (factor + factor + self._fine_pixels_per_coarse_pixel)):
-                                # add the right most portion
-                                arr_2d_view[scan_offset + row_offset + length_repeat_cycle,
+                            if self._coarse_scan_width == 270 and (expanded_arr.shape[1] - (col_offset + width_repeat_cycle + factor) <= (factor + factor + self._fine_pixels_per_coarse_pixel)):
+                                # add the right most portion (in the 270 column case)
+                                expanded_arr[scan_offset + row_offset + length_repeat_cycle,
                                             col_offset + factor + factor + self._fine_pixels_per_coarse_pixel + width_repeat_cycle] = tiepoint_value
-                            elif arr_2d_view.shape[1] - (col_offset + width_repeat_cycle + factor) <= (factor + factor):
-                                # add the right most portion
-                                arr_2d_view[scan_offset + row_offset + length_repeat_cycle,
+                            elif expanded_arr.shape[1] - (col_offset + width_repeat_cycle + factor) <= (factor + factor):
+                                # add the right most portion (in all cases including 270 column case)
+                                expanded_arr[scan_offset + row_offset + length_repeat_cycle,
                                             col_offset + factor + factor + width_repeat_cycle] = tiepoint_value

--- a/geotiepoints/_modis_interpolator.pyx
+++ b/geotiepoints/_modis_interpolator.pyx
@@ -227,6 +227,12 @@ cdef class Interpolator:
         la11 = np.ascontiguousarray(lat1)
         satz1 = np.ascontiguousarray(satz1)
 
+        cdef np.ndarray[floating, ndim=2] a_track, a_scan, new_lons, new_lats
+        a_track, a_scan = self._get_atrack_ascan(satz1)
+        new_lons, new_lats = self._interpolate_lons_lats(lon1, lat1, a_track, a_scan)
+        return new_lons, new_lats
+
+    cdef tuple _get_atrack_ascan(self, np.ndarray[floating, ndim=2] satz1):
         cdef unsigned int scans = satz1.shape[0] // self._coarse_scan_length
         # reshape to (num scans, rows per scan, columns per scan)
         cdef np.ndarray[floating, ndim=3] satz1_3d = satz1.reshape((-1, self._coarse_scan_length, self._coarse_scan_width))
@@ -257,7 +263,13 @@ cdef class Interpolator:
 
         cdef np.ndarray[floating, ndim=2] a_track = s_t
         cdef np.ndarray[floating, ndim=2] a_scan = s_s + s_s * (1 - s_s) * c_exp_full + s_t * (1 - s_t) * c_ali_full
+        return a_track, a_scan
 
+    cdef tuple _interpolate_lons_lats(self,
+                                      np.ndarray[floating, ndim=2] lon1,
+                                      np.ndarray[floating, ndim=2] lat1,
+                                      np.ndarray[floating, ndim=2] a_track,
+                                      np.ndarray[floating, ndim=2] a_scan):
         res = []
         cdef np.ndarray[floating, ndim=3] lon1_3d, lat1_3d
         lon1_3d = lon1.reshape((-1, self._coarse_scan_length, self._coarse_scan_width))

--- a/geotiepoints/_modis_interpolator.pyx
+++ b/geotiepoints/_modis_interpolator.pyx
@@ -546,7 +546,8 @@ cdef class Interpolator:
     cdef void _expand_tiepoint_array_5km(self, floating[:, :, :] arr, floating[:, ::1] arr_2d_view) nogil:
         cdef floating tiepoint_value
         cdef Py_ssize_t scan_idx, row_idx, col_idx, length_repeat_cycle, width_repeat_cycle, scan_offset, row_offset, col_offset
-        cdef Py_ssize_t factor = self._fine_pixels_per_coarse_pixel
+        # partial rows/columns to repeat: 5km->1km => 2, 5km->500m => 4, 5km->250m => 8
+        cdef Py_ssize_t factor = self._fine_pixels_per_coarse_pixel // self._coarse_pixels_per_1km * 2
         for scan_idx in range(arr.shape[0]):
             scan_offset = scan_idx * self._fine_pixels_per_coarse_pixel * self._coarse_scan_length
             for row_idx in range(arr.shape[1]):

--- a/geotiepoints/modisinterpolator.py
+++ b/geotiepoints/modisinterpolator.py
@@ -27,246 +27,31 @@ Compact VIIRS SDR Product Format User Guide (V1J)
 http://www.eumetsat.int/website/wcm/idc/idcplg?IdcService=GET_FILE&dDocName=PDF_DMT_708025&RevisionSelectionMethod=LatestReleased&Rendition=Web
 """
 
-import numpy as np
 import warnings
 
-from .geointerpolator import lonlat2xyz, xyz2lonlat
-from .simple_modis_interpolator import scanline_mapblocks
-
-R = 6371.0
-# Aqua scan width and altitude in km
-scan_width = 10.00017
-H = 705.0
-
-
-def _compute_phi(zeta):
-    return np.arcsin(R * np.sin(zeta) / (R + H))
-
-
-def _compute_theta(zeta, phi):
-    return zeta - phi
-
-
-def _compute_zeta(phi):
-    return np.arcsin((R + H) * np.sin(phi) / R)
-
-
-def _compute_expansion_alignment(satz_a, satz_b):
-    """All angles in radians."""
-    zeta_a = satz_a
-    zeta_b = satz_b
-
-    phi_a = _compute_phi(zeta_a)
-    phi_b = _compute_phi(zeta_b)
-    theta_a = _compute_theta(zeta_a, phi_a)
-    theta_b = _compute_theta(zeta_b, phi_b)
-    phi = (phi_a + phi_b) / 2
-    zeta = _compute_zeta(phi)
-    theta = _compute_theta(zeta, phi)
-    # Workaround for tiepoints symetrical about the subsatellite-track
-    denominator = np.where(theta_a == theta_b, theta_a * 2, theta_a - theta_b)
-
-    c_expansion = 4 * (((theta_a + theta_b) / 2 - theta) / denominator)
-
-    sin_beta_2 = scan_width / (2 * H)
-
-    d = ((R + H) / R * np.cos(phi) - np.cos(zeta)) * sin_beta_2
-    e = np.cos(zeta) - np.sqrt(np.cos(zeta) ** 2 - d ** 2)
-
-    c_alignment = 4 * e * np.sin(zeta) / denominator
-
-    return c_expansion, c_alignment
-
-
-def _get_corners(arr):
-    arr_a = arr[:, :-1, :-1]
-    arr_b = arr[:, :-1, 1:]
-    arr_c = arr[:, 1:, 1:]
-    arr_d = arr[:, 1:, :-1]
-    return arr_a, arr_b, arr_c, arr_d
-
-
-@scanline_mapblocks
-def _interpolate(
-        lon1,
-        lat1,
-        satz1,
-        coarse_resolution=None,
-        fine_resolution=None,
-        coarse_scan_width=None,
-):
-    """Helper function to interpolate scan-aligned arrays.
-
-    This function's decorator runs this function for each dask block/chunk of
-    scans. The arrays are scan-aligned meaning they are an even number of scans
-    (N rows per scan) and contain the entire scan width.
-
-    """
-    interp = _Interpolator(coarse_resolution, fine_resolution, coarse_scan_width=coarse_scan_width)
-    return interp.interpolate(lon1, lat1, satz1)
-
-
-class _Interpolator:
-    """Helper class for MODIS interpolation.
-
-    Not intended for public use. Use ``modis_X_to_Y`` functions instead.
-
-    """
-    def __init__(self, coarse_resolution, fine_resolution, coarse_scan_width=None):
-        if coarse_resolution == 1000:
-            coarse_scan_length = 10
-            coarse_scan_width = 1354
-            self._get_coords = self._get_coords_1km
-            self._expand_tiepoint_array = self._expand_tiepoint_array_1km
-        elif coarse_resolution == 5000:
-            coarse_scan_length = 2
-            self._get_coords = self._get_coords_5km
-            self._expand_tiepoint_array = self._expand_tiepoint_array_5km
-            if coarse_scan_width is None:
-                coarse_scan_width = 271
-            else:
-                coarse_scan_width = coarse_scan_width
-        self._coarse_scan_length = coarse_scan_length
-        self._coarse_scan_width = coarse_scan_width
-        self._coarse_pixels_per_1km = coarse_resolution // 1000
-
-        fine_pixels_per_1km = {
-            250: 4,
-            500: 2,
-            1000: 1,
-        }[fine_resolution]
-        self._fine_pixels_per_coarse_pixel = fine_pixels_per_1km * self._coarse_pixels_per_1km
-        self._fine_scan_width = 1354 * fine_pixels_per_1km
-        self._fine_scan_length = fine_pixels_per_1km * 10 // coarse_scan_length
-        self._coarse_resolution = coarse_resolution
-        self._fine_resolution = fine_resolution
-
-    def interpolate(self, lon1, lat1, satz1):
-        """Interpolate MODIS geolocation from 'coarse_resolution' to 'fine_resolution'."""
-        scans = satz1.shape[0] // self._coarse_scan_length
-        # reshape to (num scans, rows per scan, columns per scan)
-        satz1 = satz1.reshape((-1, self._coarse_scan_length, self._coarse_scan_width))
-
-        satz_a, satz_b = _get_corners(np.deg2rad(satz1))[:2]
-        c_exp, c_ali = _compute_expansion_alignment(satz_a, satz_b)
-
-        x, y = self._get_coords(scans)
-        i_rs, i_rt = np.meshgrid(x, y)
-
-        p_os = 0
-        p_ot = 0
-        s_s = (p_os + i_rs) * 1.0 / self._fine_pixels_per_coarse_pixel
-        s_t = (p_ot + i_rt) * 1.0 / self._fine_scan_length
-
-        c_exp_full = self._expand_tiepoint_array(c_exp)
-        c_ali_full = self._expand_tiepoint_array(c_ali)
-
-        a_track = s_t
-        a_scan = s_s + s_s * (1 - s_s) * c_exp_full + s_t * (1 - s_t) * c_ali_full
-
-        res = []
-        datasets = lonlat2xyz(lon1, lat1)
-        for data in datasets:
-            data = data.reshape((-1, self._coarse_scan_length, self._coarse_scan_width))
-            data_a, data_b, data_c, data_d = _get_corners(data)
-            data_a = self._expand_tiepoint_array(data_a)
-            data_b = self._expand_tiepoint_array(data_b)
-            data_c = self._expand_tiepoint_array(data_c)
-            data_d = self._expand_tiepoint_array(data_d)
-
-            data_1 = (1 - a_scan) * data_a + a_scan * data_b
-            data_2 = (1 - a_scan) * data_d + a_scan * data_c
-            data = (1 - a_track) * data_1 + a_track * data_2
-
-            res.append(data)
-        new_lons, new_lats = xyz2lonlat(*res)
-        return new_lons.astype(lon1.dtype), new_lats.astype(lat1.dtype)
-
-    def _get_coords_1km(self, scans):
-        y = (
-            np.arange((self._coarse_scan_length + 1) * self._fine_scan_length) % self._fine_scan_length
-        ) + 0.5
-        half_scan_length = self._fine_scan_length // 2
-        y = y[half_scan_length:-half_scan_length]
-        y[:half_scan_length] = np.arange(-self._fine_scan_length / 2 + 0.5, 0)
-        y[-half_scan_length:] = np.arange(self._fine_scan_length + 0.5, self._fine_scan_length * 3 / 2)
-        y = np.tile(y, scans)
-
-        x = np.arange(self._fine_scan_width) % self._fine_pixels_per_coarse_pixel
-        x[-self._fine_pixels_per_coarse_pixel:] = np.arange(
-            self._fine_pixels_per_coarse_pixel,
-            self._fine_pixels_per_coarse_pixel * 2)
-        return x, y
-
-    def _get_coords_5km(self, scans):
-        y = np.arange(self._fine_scan_length * self._coarse_scan_length) - 2
-        y = np.tile(y, scans)
-
-        x = (np.arange(self._fine_scan_width) - 2) % self._fine_pixels_per_coarse_pixel
-        x[0] = -2
-        x[1] = -1
-        if self._coarse_scan_width == 271:
-            x[-2] = 5
-            x[-1] = 6
-        elif self._coarse_scan_width == 270:
-            x[-7] = 5
-            x[-6] = 6
-            x[-5] = 7
-            x[-4] = 8
-            x[-3] = 9
-            x[-2] = 10
-            x[-1] = 11
-        else:
-            raise NotImplementedError(
-                "Can't interpolate if 5km tiepoints have less than 270 columns."
-            )
-        return x, y
-
-    def _expand_tiepoint_array_1km(self, arr):
-        arr = np.repeat(arr, self._fine_scan_length, axis=1)
-        arr = np.concatenate(
-            (arr[:, :self._fine_scan_length // 2, :], arr, arr[:, -(self._fine_scan_length // 2):, :]), axis=1
-        )
-        arr = np.repeat(arr.reshape((-1, self._coarse_scan_width - 1)), self._fine_pixels_per_coarse_pixel, axis=1)
-        return np.hstack((arr, arr[:, -self._fine_pixels_per_coarse_pixel:]))
-
-    def _expand_tiepoint_array_5km(self, arr):
-        arr = np.repeat(arr, self._fine_scan_length * 2, axis=1)
-        arr = np.repeat(arr.reshape((-1, self._coarse_scan_width - 1)), self._fine_pixels_per_coarse_pixel, axis=1)
-        factor = self._fine_pixels_per_coarse_pixel // self._coarse_pixels_per_1km
-        if self._coarse_scan_width == 271:
-            return np.hstack((arr[:, :2 * factor], arr, arr[:, -2 * factor:]))
-        else:
-            return np.hstack(
-                (
-                    arr[:, :2 * factor],
-                    arr,
-                    arr[:, -self._fine_pixels_per_coarse_pixel:],
-                    arr[:, -2 * factor:],
-                )
-            )
+from ._modis_interpolator import interpolate
 
 
 def modis_1km_to_250m(lon1, lat1, satz1):
     """Interpolate MODIS geolocation from 1km to 250m resolution."""
-    return _interpolate(lon1, lat1, satz1,
-                        coarse_resolution=1000,
-                        fine_resolution=250)
+    return interpolate(lon1, lat1, satz1,
+                       coarse_resolution=1000,
+                       fine_resolution=250)
 
 
 def modis_1km_to_500m(lon1, lat1, satz1):
     """Interpolate MODIS geolocation from 1km to 500m resolution."""
-    return _interpolate(lon1, lat1, satz1,
-                        coarse_resolution=1000,
-                        fine_resolution=500)
+    return interpolate(lon1, lat1, satz1,
+                       coarse_resolution=1000,
+                       fine_resolution=500)
 
 
 def modis_5km_to_1km(lon1, lat1, satz1):
     """Interpolate MODIS geolocation from 5km to 1km resolution."""
-    return _interpolate(lon1, lat1, satz1,
-                        coarse_resolution=5000,
-                        fine_resolution=1000,
-                        coarse_scan_width=lon1.shape[1])
+    return interpolate(lon1, lat1, satz1,
+                       coarse_resolution=5000,
+                       fine_resolution=1000,
+                       coarse_scan_width=lon1.shape[1])
 
 
 def modis_5km_to_500m(lon1, lat1, satz1):
@@ -274,10 +59,10 @@ def modis_5km_to_500m(lon1, lat1, satz1):
     warnings.warn(
         "Interpolating 5km geolocation to 500m resolution " "may result in poor quality"
     )
-    return _interpolate(lon1, lat1, satz1,
-                        coarse_resolution=5000,
-                        fine_resolution=500,
-                        coarse_scan_width=lon1.shape[1])
+    return interpolate(lon1, lat1, satz1,
+                       coarse_resolution=5000,
+                       fine_resolution=500,
+                       coarse_scan_width=lon1.shape[1])
 
 
 def modis_5km_to_250m(lon1, lat1, satz1):
@@ -285,7 +70,7 @@ def modis_5km_to_250m(lon1, lat1, satz1):
     warnings.warn(
         "Interpolating 5km geolocation to 250m resolution " "may result in poor quality"
     )
-    return _interpolate(lon1, lat1, satz1,
-                        coarse_resolution=5000,
-                        fine_resolution=250,
-                        coarse_scan_width=lon1.shape[1])
+    return interpolate(lon1, lat1, satz1,
+                       coarse_resolution=5000,
+                       fine_resolution=250,
+                       coarse_scan_width=lon1.shape[1])

--- a/geotiepoints/modisinterpolator.py
+++ b/geotiepoints/modisinterpolator.py
@@ -125,7 +125,6 @@ def _interpolate(
             coarse_scan_width = coarse_scan_width
     coarse_pixels_per_1km = coarse_resolution // 1000
 
-    res_factor = coarse_resolution // fine_resolution
     fine_pixels_per_1km = {
         250: 4,
         500: 2,

--- a/geotiepoints/modisinterpolator.py
+++ b/geotiepoints/modisinterpolator.py
@@ -107,11 +107,6 @@ class ModisInterpolator:
             500: 2,
             1000: 1,
         }[fine_resolution]
-        # course == 5km, fine == 500 -> 2 * 5 = 10
-        # equivalent to course // fine?
-        # course == 5km, fine == 250 -> 4 * 5 = 20
-        # course == 1km, fine == 500 -> 2 * 1 = 2
-        # course == 1km, fine == 1km -> 1 * 1 = 1
         self.fine_pixels_per_course_pixel = (
             fine_pixels_per_1km * self._course_pixels_per_1km
         )

--- a/geotiepoints/modisinterpolator.py
+++ b/geotiepoints/modisinterpolator.py
@@ -96,8 +96,12 @@ class _Interpolator:
         if coarse_resolution == 1000:
             coarse_scan_length = 10
             coarse_scan_width = 1354
+            self._get_coords = self._get_coords_1km
+            self._expand_tiepoint_array = self._expand_tiepoint_array_1km
         elif coarse_resolution == 5000:
             coarse_scan_length = 2
+            self._get_coords = self._get_coords_5km
+            self._expand_tiepoint_array = self._expand_tiepoint_array_5km
             if coarse_scan_width is None:
                 coarse_scan_width = 271
             else:
@@ -114,12 +118,6 @@ class _Interpolator:
         self._fine_pixels_per_coarse_pixel = fine_pixels_per_1km * self._coarse_pixels_per_1km
         self._fine_scan_width = 1354 * fine_pixels_per_1km
         self._fine_scan_length = fine_pixels_per_1km * 10 // coarse_scan_length
-        if coarse_resolution == 1000:
-            self._get_coords = self._get_coords_1km
-            self._expand_tiepoint_array = self._expand_tiepoint_array_1km
-        else:
-            self._get_coords = self._get_coords_5km
-            self._expand_tiepoint_array = self._expand_tiepoint_array_5km
         self._coarse_resolution = coarse_resolution
         self._fine_resolution = fine_resolution
 

--- a/geotiepoints/modisinterpolator.py
+++ b/geotiepoints/modisinterpolator.py
@@ -160,7 +160,6 @@ def _interpolate(
 
     p_os = 0
     p_ot = 0
-
     s_s = (p_os + i_rs) * 1.0 / fine_pixels_per_coarse_pixel
     s_t = (p_ot + i_rt) * 1.0 / fine_scan_length
 
@@ -283,11 +282,11 @@ def _expand_tiepoint_array_1km(
     coarse_scan_width,
     fine_pixels_per_coarse_pixel,
     arr,
-    find_scan_length,
+    fine_scan_length,
 ):
-    arr = np.repeat(arr, find_scan_length, axis=1)
+    arr = np.repeat(arr, fine_scan_length, axis=1)
     arr = np.concatenate(
-        (arr[:, : find_scan_length // 2, :], arr, arr[:, -(find_scan_length // 2):, :]), axis=1
+        (arr[:, : fine_scan_length // 2, :], arr, arr[:, -(fine_scan_length // 2):, :]), axis=1
     )
     arr = np.repeat(arr.reshape((-1, coarse_scan_width - 1)), fine_pixels_per_coarse_pixel, axis=1)
     return np.hstack((arr, arr[:, -fine_pixels_per_coarse_pixel:]))

--- a/geotiepoints/modisinterpolator.py
+++ b/geotiepoints/modisinterpolator.py
@@ -51,7 +51,7 @@ def _compute_zeta(phi):
     return np.arcsin((R + H) * np.sin(phi) / R)
 
 
-def _compute_expansion_alignment(satz_a, satz_b, satz_c, satz_d):
+def _compute_expansion_alignment(satz_a, satz_b):
     """All angles in radians."""
     zeta_a = satz_a
     zeta_b = satz_b
@@ -125,9 +125,9 @@ def _interpolate(
     # reshape to (num scans, rows per scan, columns per scan)
     satz1 = satz1.reshape((-1, coarse_scan_length, coarse_scan_width))
 
-    satz_a, satz_b, satz_c, satz_d = _get_corners(np.deg2rad(satz1))
+    satz_a, satz_b = _get_corners(np.deg2rad(satz1))[:2]
 
-    c_exp, c_ali = _compute_expansion_alignment(satz_a, satz_b, satz_c, satz_d)
+    c_exp, c_ali = _compute_expansion_alignment(satz_a, satz_b)
 
     x, y = get_coords(
         coarse_scan_length,

--- a/geotiepoints/modisinterpolator.py
+++ b/geotiepoints/modisinterpolator.py
@@ -40,30 +40,30 @@ scan_width = 10.00017
 H = 705.
 
 
-def compute_phi(zeta):
+def _compute_phi(zeta):
     return np.arcsin(R * np.sin(zeta) / (R + H))
 
 
-def compute_theta(zeta, phi):
+def _compute_theta(zeta, phi):
     return zeta - phi
 
 
-def compute_zeta(phi):
+def _compute_zeta(phi):
     return np.arcsin((R + H) * np.sin(phi) / R)
 
 
-def compute_expansion_alignment(satz_a, satz_b, satz_c, satz_d):
+def _compute_expansion_alignment(satz_a, satz_b, satz_c, satz_d):
     """All angles in radians."""
     zeta_a = satz_a
     zeta_b = satz_b
 
-    phi_a = compute_phi(zeta_a)
-    phi_b = compute_phi(zeta_b)
-    theta_a = compute_theta(zeta_a, phi_a)
-    theta_b = compute_theta(zeta_b, phi_b)
+    phi_a = _compute_phi(zeta_a)
+    phi_b = _compute_phi(zeta_b)
+    theta_a = _compute_theta(zeta_a, phi_a)
+    theta_b = _compute_theta(zeta_b, phi_b)
     phi = (phi_a + phi_b) / 2
-    zeta = compute_zeta(phi)
-    theta = compute_theta(zeta, phi)
+    zeta = _compute_zeta(phi)
+    theta = _compute_theta(zeta, phi)
     # Workaround for tiepoints symetrical about the subsatellite-track
     denominator = np.where(theta_a == theta_b, theta_a * 2, theta_a - theta_b)
 
@@ -79,7 +79,7 @@ def compute_expansion_alignment(satz_a, satz_b, satz_c, satz_d):
     return c_expansion, c_alignment
 
 
-def get_corners(arr):
+def _get_corners(arr):
     arr_a = arr[:, :-1, :-1]
     arr_b = arr[:, :-1, 1:]
     arr_c = arr[:, 1:, 1:]
@@ -156,9 +156,9 @@ def _interpolate(
     scans = satz1.shape[0] // cscan_len
     satz1 = satz1.reshape((-1, cscan_len, cscan_full_width))
 
-    satz_a, satz_b, satz_c, satz_d = get_corners(np.deg2rad(satz1))
+    satz_a, satz_b, satz_c, satz_d = _get_corners(np.deg2rad(satz1))
 
-    c_exp, c_ali = compute_expansion_alignment(satz_a, satz_b, satz_c, satz_d)
+    c_exp, c_ali = _compute_expansion_alignment(satz_a, satz_b, satz_c, satz_d)
 
     x, y = get_coords(cscan_len, cscan_full_width, fscan_len, fscan_width, fscan_full_width, scans)
     i_rs, i_rt = np.meshgrid(x, y)
@@ -182,7 +182,7 @@ def _interpolate(
     datasets = lonlat2xyz(lon1, lat1)
     for data in datasets:
         data = data.reshape((-1, cscan_len, cscan_full_width))
-        data_a, data_b, data_c, data_d = get_corners(data)
+        data_a, data_b, data_c, data_d = _get_corners(data)
         data_a = expand_tiepoint_array(cscan_width, cscan_full_width, fscan_width, data_a, lines, cols)
         data_b = expand_tiepoint_array(cscan_width, cscan_full_width, fscan_width, data_b, lines, cols)
         data_c = expand_tiepoint_array(cscan_width, cscan_full_width, fscan_width, data_c, lines, cols)

--- a/geotiepoints/simple_modis_interpolator.py
+++ b/geotiepoints/simple_modis_interpolator.py
@@ -106,7 +106,6 @@ def _extract_dask_arrays_from_args(args):
     return [arr_obj.data if hasattr(arr_obj, "dims") else arr_obj for arr_obj in args]
 
 
-
 def _call_map_blocks_interp(func, coarse_resolution, fine_resolution, *args, **kwargs):
     first_arr = [arr for arr in args if hasattr(arr, "ndim")][0]
     res_factor = coarse_resolution // fine_resolution

--- a/geotiepoints/tests/test_modisinterpolator.py
+++ b/geotiepoints/tests/test_modisinterpolator.py
@@ -50,34 +50,34 @@ class TestModisInterpolator(unittest.TestCase):
         lat500 = to_da(h5f['lat_500m'])
 
         lons, lats = modis_1km_to_250m(lon1, lat1, satz1)
-        self.assertTrue(np.allclose(lon250, lons, atol=1e-2))
-        self.assertTrue(np.allclose(lat250, lats, atol=1e-2))
+        np.testing.assert_allclose(lon250, lons, atol=1e-2)
+        np.testing.assert_allclose(lat250, lats, atol=1e-2)
 
         lons, lats = modis_1km_to_500m(lon1, lat1, satz1)
-        self.assertTrue(np.allclose(lon500, lons, atol=1e-2))
-        self.assertTrue(np.allclose(lat500, lats, atol=1e-2))
+        np.testing.assert_allclose(lon500, lons, atol=1e-2)
+        np.testing.assert_allclose(lat500, lats, atol=1e-2)
 
         lat5 = lat1[2::5, 2::5]
         lon5 = lon1[2::5, 2::5]
 
         satz5 = satz1[2::5, 2::5]
         lons, lats = modis_5km_to_1km(lon5, lat5, satz5)
-        self.assertTrue(np.allclose(lon1, lons, atol=1e-2))
-        self.assertTrue(np.allclose(lat1, lats, atol=1e-2))
+        np.testing.assert_allclose(lon1, lons, atol=1e-2)
+        np.testing.assert_allclose(lat1, lats, atol=1e-2)
 
         # 5km to 500m
         lons, lats = modis_5km_to_500m(lon5, lat5, satz5)
         self.assertEqual(lon500.shape, lons.shape)
         self.assertEqual(lat500.shape, lats.shape)
-        # self.assertTrue(np.allclose(lon500, lons, atol=1e-2))
-        # self.assertTrue(np.allclose(lat500, lats, atol=1e-2))
+        # np.testing.assert_allclose(lon500, lons, atol=1e-2)
+        # np.testing.assert_allclose(lat500, lats, atol=1e-2)
 
         # 5km to 250m
         lons, lats = modis_5km_to_250m(lon5, lat5, satz5)
         self.assertEqual(lon250.shape, lons.shape)
         self.assertEqual(lat250.shape, lats.shape)
-        # self.assertTrue(np.allclose(lon250, lons, atol=1e-2))
-        # self.assertTrue(np.allclose(lat250, lats, atol=1e-2))
+        # np.testing.assert_allclose(lon250, lons, atol=1e-2)
+        # np.testing.assert_allclose(lat250, lats, atol=1e-2)
 
         # Test level 2
         lat5 = lat1[2::5, 2:-5:5]
@@ -85,11 +85,11 @@ class TestModisInterpolator(unittest.TestCase):
 
         satz5 = satz1[2::5, 2:-5:5]
         lons, lats = modis_5km_to_1km(lon5, lat5, satz5)
-        self.assertTrue(np.allclose(lon1, lons, atol=1e-2))
-        self.assertTrue(np.allclose(lat1, lats, atol=1e-2))
+        np.testing.assert_allclose(lon1, lons, atol=1e-2)
+        np.testing.assert_allclose(lat1, lats, atol=1e-2)
 
         # Test nans issue (#19)
-        satz1 = to_da(abs(np.linspace(-65.4, 65.4, 1354)).repeat(20).reshape(-1, 20).T)
+        satz1 = to_da(abs(np.linspace(-65.4, 65.4, 1354, dtype=np.float32)).repeat(20).reshape(-1, 20).T)
         lons, lats = modis_1km_to_500m(lon1, lat1, satz1)
         self.assertFalse(np.any(np.isnan(lons.compute())))
         self.assertFalse(np.any(np.isnan(lats.compute())))
@@ -110,5 +110,5 @@ class TestModisInterpolator(unittest.TestCase):
         lons, lats = modis_5km_to_1km(lon5, lat5, satz5)
         lons = lons + 180
         lons = xr.where(lons > 180, lons - 360, lons)
-        self.assertTrue(np.allclose(orig_lon, lons, atol=1e-2))
-        self.assertTrue(np.allclose(lat1, lats, atol=1e-2))
+        np.testing.assert_allclose(orig_lon, lons, atol=1e-2)
+        np.testing.assert_allclose(lat1, lats, atol=1e-2)

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,12 @@ EXTENSIONS = [
         extra_compile_args=extra_compile_args,
         include_dirs=[np.get_include()],
     ),
+    Extension(
+        'geotiepoints._modis_interpolator',
+        sources=['geotiepoints/_modis_interpolator.pyx'],
+        extra_compile_args=extra_compile_args,
+        include_dirs=[np.get_include()],
+    ),
 ]
 
 cmdclass = versioneer.get_cmdclass()
@@ -70,7 +76,7 @@ if __name__ == "__main__":
           python_requires='>=3.6',
           cmdclass=cmdclass,
           install_requires=requirements,
-          ext_modules=cythonize(EXTENSIONS),
+          ext_modules=cythonize(EXTENSIONS, compiler_directives={'language_level': '3'}),
           tests_require=test_requires,
           zip_safe=False
           )


### PR DESCRIPTION
Replacement (add on) to #35. This is an attempt at making the interpolation faster or at least more memory efficient by converting it to cython. There are a few gotchas involved as there is a conversion from 32-bit floating point space to 64-bit floating point space and the unit tests fail if 32-bit values are returned, even if the casting to 32-bit is done as the last step.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes) -->
 - [ ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->