### PR TITLE
Rewrite simple modis interpolation in cython

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include doc/Makefile
 recursive-include doc/source *
 include LICENSE.txt
-include geotiepoints/multilinear_cython.pyx
+include geotiepoints/*.pyx
+include geotiepoints/*.pxd
 include versioneer.py
 include geotiepoints/version.py

--- a/geotiepoints/_modis_interpolator.pyx
+++ b/geotiepoints/_modis_interpolator.pyx
@@ -331,8 +331,6 @@ cdef class Interpolator:
         lonlat2xyz(lon1_c, lat1_c, xyz_c_view)
         lonlat2xyz(lon1_d, lat1_d, xyz_d_view)
 
-        cdef np.ndarray[floating, ndim=3] data
-        # cdef np.ndarray[floating, ndim=3] data_a, data_b, data_c, data_d
         cdef np.ndarray[floating, ndim=2] data_a_2d, data_b_2d, data_c_2d, data_d_2d
         cdef np.ndarray[floating, ndim=3] comp_arr_2d = np.empty((a_scan.shape[0], a_scan.shape[1], 3), dtype=lon1.dtype)
         cdef floating[:, :, ::1] xyz_comp_view = comp_arr_2d
@@ -341,8 +339,8 @@ cdef class Interpolator:
         cdef floating scan1_tmp, scan2_tmp, atrack1, ascan1
         cdef floating[:, ::1] data_a_2d_view, data_b_2d_view, data_c_2d_view, data_d_2d_view
         cdef np.ndarray[floating, ndim=3] comp_a, comp_b, comp_c, comp_d
-        print(a_scan.shape[0], a_scan.shape[1], a_track.shape[0], a_track.shape[1], comp_arr_2d.shape[0], comp_arr_2d.shape[1], comp_arr_2d.shape[2])
-        print(xyz_a.shape[0], xyz_a.shape[1], xyz_a.shape[2], xyz_a.shape[3])
+        cdef floating[:, ::1] a_track_view = a_track
+        cdef floating[:, ::1] a_scan_view = a_scan
         for k in range(3):  # xyz
             # data_a_2d = self._expand_tiepoint_array(xyz_a[:, :, :, k])
             # data_b_2d = self._expand_tiepoint_array(xyz_b[:, :, :, k])
@@ -360,26 +358,14 @@ cdef class Interpolator:
             data_b_2d_view = data_b_2d
             data_c_2d_view = data_c_2d
             data_d_2d_view = data_d_2d
-            print(data_a_2d.shape[0], data_a_2d.shape[1], data_b_2d.shape[0], data_b_2d.shape[1])
-            # TODO: assign views
             for i in range(a_scan.shape[0]):
                 for j in range(a_scan.shape[1]):
-                    atrack1 = a_track[i, j]
-                    ascan1 = a_scan[i, j]
+                    atrack1 = a_track_view[i, j]
+                    ascan1 = a_scan_view[i, j]
                     scan1_tmp = (1 - ascan1) * data_a_2d_view[i, j] + ascan1 * data_b_2d_view[i, j]
                     scan2_tmp = (1 - ascan1) * data_d_2d_view[i, j] + ascan1 * data_c_2d_view[i, j]
                     xyz_comp_view[i, j, k] = (1 - atrack1) * scan1_tmp + atrack1 * scan2_tmp
 
-        # for xyz_comp_a, xyz_comp_b, xyz_comp_c, xyz_comp_d  in zip(xyz_a, xyz_b, xyz_c, xyz_d):
-        #     data_a_2d = self._expand_tiepoint_array(xyz_comp_a)
-        #     data_b_2d = self._expand_tiepoint_array(xyz_comp_b)
-        #     data_c_2d = self._expand_tiepoint_array(xyz_comp_c)
-        #     data_d_2d = self._expand_tiepoint_array(xyz_comp_d)
-        #
-        #     data_1 = (1 - a_scan) * data_a_2d + a_scan * data_b_2d
-        #     data_2 = (1 - a_scan) * data_d_2d + a_scan * data_c_2d
-        #     comp_arr_2d = (1 - a_track) * data_1 + a_track * data_2
-        #     res.append(comp_arr_2d)
         cdef np.ndarray[floating, ndim=2] new_lons = np.empty((a_scan.shape[0], a_scan.shape[1]), dtype=lon1.dtype)
         cdef np.ndarray[floating, ndim=2] new_lats = np.empty((a_scan.shape[0], a_scan.shape[1]), dtype=lon1.dtype)
         cdef floating[:, ::1] new_lons_view = new_lons

--- a/geotiepoints/_modis_interpolator.pyx
+++ b/geotiepoints/_modis_interpolator.pyx
@@ -11,10 +11,6 @@ ctypedef fused floating:
     np.float64_t
 
 DEF EARTH_RADIUS = 6370997.0
-# cdef np.float32_t R = 6371.0
-# # Aqua scan width and altitude in km
-# cdef np.float32_t scan_width = 10.00017
-# cdef np.float32_t H = 705.0
 DEF R = 6371.0
 # Aqua scan width and altitude in km
 DEF scan_width = 10.00017
@@ -274,7 +270,6 @@ cdef class Interpolator:
         cdef unsigned int scans = satz1.shape[0] // self._coarse_scan_length
         # reshape to (num scans, rows per scan, columns per scan)
         cdef floating[:, :, ::1] satz1_3d = satz1.reshape((-1, self._coarse_scan_length, self._coarse_scan_width))
-
         cdef floating[:, :, ::1] satz_a_view = _get_upper_left_corner(satz1_3d)
         cdef floating[:, :, ::1] satz_b_view = _get_upper_right_corner(satz1_3d)
         cdef np.ndarray[floating, ndim=3] c_exp = np.empty(
@@ -316,13 +311,9 @@ cdef class Interpolator:
                                       np.ndarray[floating, ndim=2] lat1,
                                       np.ndarray[floating, ndim=2] a_track,
                                       np.ndarray[floating, ndim=2] a_scan):
-        res = []
-        cdef np.ndarray[floating, ndim=3] lon1_3d, lat1_3d
-        lon1_3d = lon1.reshape((-1, self._coarse_scan_length, self._coarse_scan_width))
-        lat1_3d = lat1.reshape((-1, self._coarse_scan_length, self._coarse_scan_width))
         cdef floating[:, :, ::1] lon1_3d_view, lat1_3d_view
-        lon1_3d_view = lon1_3d
-        lat1_3d_view = lat1_3d
+        lon1_3d_view = lon1.reshape((-1, self._coarse_scan_length, self._coarse_scan_width))
+        lat1_3d_view = lat1.reshape((-1, self._coarse_scan_length, self._coarse_scan_width))
         cdef floating[:, :, ::1] lon1_a, lon1_b, lon1_c, lon1_d, lat1_a, lat1_b, lat1_c, lat1_d
         lon1_a = _get_upper_left_corner(lon1_3d_view)
         lon1_b = _get_upper_right_corner(lon1_3d_view)

--- a/geotiepoints/_modis_interpolator.pyx
+++ b/geotiepoints/_modis_interpolator.pyx
@@ -297,16 +297,16 @@ cdef class Interpolator:
 
     cdef np.ndarray[floating, ndim=2] _expand_tiepoint_array_5km(self, np.ndarray[floating, ndim=3] arr):
         arr = np.repeat(arr, self._fine_scan_length * 2, axis=1)
-        arr = np.repeat(arr.reshape((-1, self._coarse_scan_width - 1)), self._fine_pixels_per_coarse_pixel, axis=1)
+        cdef np.ndarray[floating, ndim=2] arr_2d = np.repeat(arr.reshape((-1, self._coarse_scan_width - 1)), self._fine_pixels_per_coarse_pixel, axis=1)
         factor = self._fine_pixels_per_coarse_pixel // self._coarse_pixels_per_1km
         if self._coarse_scan_width == 271:
-            return np.hstack((arr[:, :2 * factor], arr, arr[:, -2 * factor:]))
+            return np.hstack((arr_2d[:, :2 * factor], arr_2d, arr_2d[:, -2 * factor:]))
         else:
             return np.hstack(
                 (
-                    arr[:, :2 * factor],
-                    arr,
-                    arr[:, -self._fine_pixels_per_coarse_pixel:],
-                    arr[:, -2 * factor:],
+                    arr_2d[:, :2 * factor],
+                    arr_2d,
+                    arr_2d[:, -self._fine_pixels_per_coarse_pixel:],
+                    arr_2d[:, -2 * factor:],
                 )
             )

--- a/geotiepoints/_modis_interpolator.pyx
+++ b/geotiepoints/_modis_interpolator.pyx
@@ -35,8 +35,8 @@ cdef void lonlat2xyz(
     for i in range(lons.shape[0]):
         for j in range(lons.shape[1]):
             for k in range(lons.shape[2]):
-                lon_rad = _deg2rad64(lons[i, j, k])
-                lat_rad = _deg2rad64(lats[i, j, k])
+                lon_rad = _deg2rad(lons[i, j, k])
+                lat_rad = _deg2rad(lats[i, j, k])
                 xyz[i, j, k, 0] = EARTH_RADIUS * cos(lat_rad) * cos(lon_rad)
                 xyz[i, j, k, 1] = EARTH_RADIUS * cos(lat_rad) * sin(lon_rad)
                 xyz[i, j, k, 2] = EARTH_RADIUS * sin(lat_rad)
@@ -60,14 +60,14 @@ cdef void xyz2lonlat(
             x = <np.float64_t>xyz[i, j, 0]
             y = <np.float64_t>xyz[i, j, 1]
             z = <np.float64_t>xyz[i, j, 2]
-            lons[i, j] = _rad2deg64(acos(x / sqrt(x ** 2 + y ** 2))) * _sign(y)
+            lons[i, j] = _rad2deg(acos(x / sqrt(x ** 2 + y ** 2))) * _sign(y)
             # if we are at low latitudes - small z, then get the
             # latitudes only from z. If we are at high latitudes (close to the poles)
             # then derive the latitude using x and y:
             if low_lat_z and (z < thr * EARTH_RADIUS) and (z > -1.0 * thr * EARTH_RADIUS):
-                lats[i, j] = 90 - _rad2deg64(acos(z / EARTH_RADIUS))
+                lats[i, j] = 90 - _rad2deg(acos(z / EARTH_RADIUS))
             else:
-                lats[i, j] = _sign(z) * (90 - _rad2deg64(asin(sqrt(x ** 2 + y ** 2) / EARTH_RADIUS)))
+                lats[i, j] = _sign(z) * (90 - _rad2deg(asin(sqrt(x ** 2 + y ** 2) / EARTH_RADIUS)))
 
 
 cdef inline int _sign(floating x) nogil:
@@ -79,14 +79,6 @@ cdef inline floating _rad2deg(floating x) nogil:
 
 
 cdef inline floating _deg2rad(floating x) nogil:
-    return x * (M_PI / 180.0)
-
-
-cdef inline np.float64_t _rad2deg64(np.float64_t x) nogil:
-    return x * (180.0 / M_PI)
-
-
-cdef inline np.float64_t _deg2rad64(np.float64_t x) nogil:
     return x * (M_PI / 180.0)
 
 

--- a/geotiepoints/_modis_interpolator.pyx
+++ b/geotiepoints/_modis_interpolator.pyx
@@ -1,0 +1,290 @@
+from libc.math cimport fmin, fmax, floor
+cimport cython
+from cython.parallel import prange,parallel
+from .simple_modis_interpolator import scanline_mapblocks
+
+cimport numpy as np
+import numpy as np
+
+# ctypedef fused floating:
+#     float
+#     double
+
+ctypedef fused floating:
+    np.float32_t
+    np.float64_t
+
+EARTH_RADIUS = 6370997.0
+R = 6371.0
+# Aqua scan width and altitude in km
+scan_width = 10.00017
+H = 705.0
+
+
+def lonlat2xyz(
+        lons, lats,
+        # floating[:, :] lons, floating[:, :] lats,
+        floating radius=EARTH_RADIUS):
+    """Convert lons and lats to cartesian coordinates."""
+    lons_rad = np.deg2rad(lons)
+    lats_rad = np.deg2rad(lats)
+    x_coords = radius * np.cos(lats_rad) * np.cos(lons_rad)
+    y_coords = radius * np.cos(lats_rad) * np.sin(lons_rad)
+    z_coords = radius * np.sin(lats_rad)
+    return x_coords, y_coords, z_coords
+
+
+def xyz2lonlat(
+        # floating[:, :] x__,
+        # floating[:, :] y__,
+        # floating[:, :] z__,
+        # np.ndarray[floating, ndim=2] x__,
+        # np.ndarray[floating, ndim=2] y__,
+        # np.ndarray[floating, ndim=2] z__,
+        x__,
+        y__,
+        z__,
+        floating radius=EARTH_RADIUS,
+        floating thr=0.8,
+        bint low_lat_z=True):
+    """Get longitudes from cartesian coordinates."""
+    lons = np.rad2deg(np.arccos(x__ / np.sqrt(x__ ** 2 + y__ ** 2))) * np.sign(y__)
+    lats = np.sign(z__) * (90 - np.rad2deg(np.arcsin(np.sqrt(x__ ** 2 + y__ ** 2) / radius)))
+    if low_lat_z:
+        # if we are at low latitudes - small z, then get the
+        # latitudes only from z. If we are at high latitudes (close to the poles)
+        # then derive the latitude using x and y:
+        lat_mask_cond = np.logical_and(
+            np.less(z__, thr * radius),
+            np.greater(z__, -1. * thr * radius))
+        lat_z_only = 90 - np.rad2deg(np.arccos(z__ / radius))
+        lats = np.where(lat_mask_cond, lat_z_only, lats)
+
+    return lons, lats
+
+
+@scanline_mapblocks
+def interpolate(
+        np.ndarray[floating, ndim=2] lon1,
+        np.ndarray[floating, ndim=2] lat1,
+        np.ndarray[floating, ndim=2] satz1,
+        unsigned int coarse_resolution=0,
+        unsigned int fine_resolution=0,
+        unsigned int coarse_scan_width=0,
+):
+    """Helper function to interpolate scan-aligned arrays.
+
+    This function's decorator runs this function for each dask block/chunk of
+    scans. The arrays are scan-aligned meaning they are an even number of scans
+    (N rows per scan) and contain the entire scan width.
+
+    """
+    interp = Interpolator(coarse_resolution, fine_resolution, coarse_scan_width=coarse_scan_width or 0)
+    return interp.interpolate(lon1, lat1, satz1)
+
+
+def _compute_phi(zeta):
+    return np.arcsin(R * np.sin(zeta) / (R + H))
+
+
+def _compute_theta(zeta, phi):
+    return zeta - phi
+
+
+def _compute_zeta(phi):
+    return np.arcsin((R + H) * np.sin(phi) / R)
+
+
+def _compute_expansion_alignment(satz_a, satz_b):
+    """All angles in radians."""
+    zeta_a = satz_a
+    zeta_b = satz_b
+
+    phi_a = _compute_phi(zeta_a)
+    phi_b = _compute_phi(zeta_b)
+    theta_a = _compute_theta(zeta_a, phi_a)
+    theta_b = _compute_theta(zeta_b, phi_b)
+    phi = (phi_a + phi_b) / 2
+    zeta = _compute_zeta(phi)
+    theta = _compute_theta(zeta, phi)
+    # Workaround for tiepoints symetrical about the subsatellite-track
+    denominator = np.where(theta_a == theta_b, theta_a * 2, theta_a - theta_b)
+
+    c_expansion = 4 * (((theta_a + theta_b) / 2 - theta) / denominator)
+
+    sin_beta_2 = scan_width / (2 * H)
+
+    d = ((R + H) / R * np.cos(phi) - np.cos(zeta)) * sin_beta_2
+    e = np.cos(zeta) - np.sqrt(np.cos(zeta) ** 2 - d ** 2)
+
+    c_alignment = 4 * e * np.sin(zeta) / denominator
+
+    return c_expansion, c_alignment
+
+
+def _get_corners(arr):
+    arr_a = arr[:, :-1, :-1]
+    arr_b = arr[:, :-1, 1:]
+    arr_c = arr[:, 1:, 1:]
+    arr_d = arr[:, 1:, :-1]
+    return arr_a, arr_b, arr_c, arr_d
+
+
+cdef class Interpolator:
+    """Helper class for MODIS interpolation.
+
+    Not intended for public use. Use ``modis_X_to_Y`` functions instead.
+
+    """
+
+    cdef int _coarse_scan_length
+    cdef int _coarse_scan_width
+    cdef int _coarse_pixels_per_1km
+    cdef int _fine_pixels_per_coarse_pixel
+    cdef int _fine_scan_width
+    cdef int _fine_scan_length
+    cdef int _coarse_resolution
+    cdef int _fine_resolution
+    cdef _get_coords
+    cdef _expand_tiepoint_array
+
+    def __init__(self, unsigned int coarse_resolution, unsigned int fine_resolution, unsigned int coarse_scan_width=0):
+        if coarse_resolution == 1000:
+            coarse_scan_length = 10
+            coarse_scan_width = 1354
+            self._get_coords = self._get_coords_1km
+            self._expand_tiepoint_array = self._expand_tiepoint_array_1km
+        elif coarse_resolution == 5000:
+            coarse_scan_length = 2
+            self._get_coords = self._get_coords_5km
+            self._expand_tiepoint_array = self._expand_tiepoint_array_5km
+            if coarse_scan_width == 0:
+                coarse_scan_width = 271
+            else:
+                coarse_scan_width = coarse_scan_width
+        self._coarse_scan_length = coarse_scan_length
+        self._coarse_scan_width = coarse_scan_width
+        self._coarse_pixels_per_1km = coarse_resolution // 1000
+
+        fine_pixels_per_1km = {
+            250: 4,
+            500: 2,
+            1000: 1,
+        }[fine_resolution]
+        self._fine_pixels_per_coarse_pixel = fine_pixels_per_1km * self._coarse_pixels_per_1km
+        self._fine_scan_width = 1354 * fine_pixels_per_1km
+        self._fine_scan_length = fine_pixels_per_1km * 10 // coarse_scan_length
+        self._coarse_resolution = coarse_resolution
+        self._fine_resolution = fine_resolution
+
+    @cython.boundscheck(False)
+    @cython.cdivision(True)
+    @cython.wraparound(False)
+    cdef interpolate(
+            self,
+            np.ndarray[floating, ndim=2] lon1,
+            np.ndarray[floating, ndim=2] lat1,
+            np.ndarray[floating, ndim=2] satz1_):
+        """Interpolate MODIS geolocation from 'coarse_resolution' to 'fine_resolution'."""
+        scans = satz1_.shape[0] // self._coarse_scan_length
+        # reshape to (num scans, rows per scan, columns per scan)
+        satz1 = satz1_.reshape((-1, self._coarse_scan_length, self._coarse_scan_width))
+        # cdef floating [:, :, :] satz1 = satz1_.reshape((-1, self._coarse_scan_length, self._coarse_scan_width))
+
+        satz_a, satz_b = _get_corners(np.deg2rad(satz1))[:2]
+        c_exp, c_ali = _compute_expansion_alignment(satz_a, satz_b)
+
+        x, y = self._get_coords(scans)
+        i_rs, i_rt = np.meshgrid(x, y)
+
+        p_os = 0
+        p_ot = 0
+        s_s = (p_os + i_rs) * 1.0 / self._fine_pixels_per_coarse_pixel
+        s_t = (p_ot + i_rt) * 1.0 / self._fine_scan_length
+
+        c_exp_full = self._expand_tiepoint_array(c_exp)
+        c_ali_full = self._expand_tiepoint_array(c_ali)
+
+        a_track = s_t
+        a_scan = s_s + s_s * (1 - s_s) * c_exp_full + s_t * (1 - s_t) * c_ali_full
+
+        res = []
+        datasets = lonlat2xyz(lon1, lat1)
+        for data in datasets:
+            data = data.reshape((-1, self._coarse_scan_length, self._coarse_scan_width))
+            data_a, data_b, data_c, data_d = _get_corners(data)
+            data_a = self._expand_tiepoint_array(data_a)
+            data_b = self._expand_tiepoint_array(data_b)
+            data_c = self._expand_tiepoint_array(data_c)
+            data_d = self._expand_tiepoint_array(data_d)
+
+            data_1 = (1 - a_scan) * data_a + a_scan * data_b
+            data_2 = (1 - a_scan) * data_d + a_scan * data_c
+            data = (1 - a_track) * data_1 + a_track * data_2
+
+            res.append(data)
+        new_lons, new_lats = xyz2lonlat(*res)
+        return new_lons.astype(lon1.dtype), new_lats.astype(lat1.dtype)
+
+    def _get_coords_1km(self, unsigned int scans):
+        cdef np.ndarray[np.float32_t, ndim=1] y = (np.arange((self._coarse_scan_length + 1) * self._fine_scan_length, dtype=np.float32) % self._fine_scan_length) + 0.5
+        cdef int half_scan_length = self._fine_scan_length // 2
+        cdef np.ndarray[np.float32_t, ndim=1] y2 = y[half_scan_length:-half_scan_length]
+        y2[:half_scan_length] = np.arange(-self._fine_scan_length / 2 + 0.5, 0)
+        y2[-half_scan_length:] = np.arange(self._fine_scan_length + 0.5, self._fine_scan_length * 3 / 2)
+        cdef np.ndarray[np.float32_t, ndim=1] y3 = np.tile(y2, scans)
+
+        cdef np.ndarray[np.float32_t, ndim=1] x = np.arange(self._fine_scan_width, dtype=np.float32) % self._fine_pixels_per_coarse_pixel
+        x[-self._fine_pixels_per_coarse_pixel:] = np.arange(
+            self._fine_pixels_per_coarse_pixel,
+            self._fine_pixels_per_coarse_pixel * 2)
+        return x, y3
+
+    # def _get_coords_5km(self, unsigned int scans):
+    def _get_coords_5km(self, scans):
+        y = np.arange(self._fine_scan_length * self._coarse_scan_length) - 2
+        y = np.tile(y, scans)
+
+        x = (np.arange(self._fine_scan_width) - 2) % self._fine_pixels_per_coarse_pixel
+        x[0] = -2
+        x[1] = -1
+        if self._coarse_scan_width == 271:
+            x[-2] = 5
+            x[-1] = 6
+        elif self._coarse_scan_width == 270:
+            x[-7] = 5
+            x[-6] = 6
+            x[-5] = 7
+            x[-4] = 8
+            x[-3] = 9
+            x[-2] = 10
+            x[-1] = 11
+        else:
+            raise NotImplementedError(
+                "Can't interpolate if 5km tiepoints have less than 270 columns."
+            )
+        return x, y
+
+    def _expand_tiepoint_array_1km(self, arr):
+        arr = np.repeat(arr, self._fine_scan_length, axis=1)
+        arr = np.concatenate(
+            (arr[:, :self._fine_scan_length // 2, :], arr, arr[:, -(self._fine_scan_length // 2):, :]), axis=1
+        )
+        arr = np.repeat(arr.reshape((-1, self._coarse_scan_width - 1)), self._fine_pixels_per_coarse_pixel, axis=1)
+        return np.hstack((arr, arr[:, -self._fine_pixels_per_coarse_pixel:]))
+
+    def _expand_tiepoint_array_5km(self, arr):
+        arr = np.repeat(arr, self._fine_scan_length * 2, axis=1)
+        arr = np.repeat(arr.reshape((-1, self._coarse_scan_width - 1)), self._fine_pixels_per_coarse_pixel, axis=1)
+        factor = self._fine_pixels_per_coarse_pixel // self._coarse_pixels_per_1km
+        if self._coarse_scan_width == 271:
+            return np.hstack((arr[:, :2 * factor], arr, arr[:, -2 * factor:]))
+        else:
+            return np.hstack(
+                (
+                    arr[:, :2 * factor],
+                    arr,
+                    arr[:, -self._fine_pixels_per_coarse_pixel:],
+                    arr[:, -2 * factor:],
+                )
+            )

--- a/geotiepoints/_modis_interpolator.pyx
+++ b/geotiepoints/_modis_interpolator.pyx
@@ -227,6 +227,12 @@ cdef class Interpolator:
         la11 = np.ascontiguousarray(lat1)
         satz1 = np.ascontiguousarray(satz1)
 
+        cdef np.ndarray[floating, ndim=2] a_track, a_scan, new_lons, new_lats
+        a_track, a_scan = self._get_atrack_ascan(satz1)
+        new_lons, new_lats = self._interpolate_lons_lats(lon1, lat1, a_track, a_scan)
+        return new_lons, new_lats
+
+    cdef tuple _get_atrack_ascan(self, np.ndarray[floating, ndim=2] satz1):
         cdef unsigned int scans = satz1.shape[0] // self._coarse_scan_length
         # reshape to (num scans, rows per scan, columns per scan)
         cdef np.ndarray[floating, ndim=3] satz1_3d = satz1.reshape((-1, self._coarse_scan_length, self._coarse_scan_width))
@@ -257,7 +263,13 @@ cdef class Interpolator:
 
         cdef np.ndarray[floating, ndim=2] a_track = s_t
         cdef np.ndarray[floating, ndim=2] a_scan = s_s + s_s * (1 - s_s) * c_exp_full + s_t * (1 - s_t) * c_ali_full
+        return a_track, a_scan
 
+    cdef tuple _interpolate_lons_lats(self,
+                                      np.ndarray[floating, ndim=2] lon1,
+                                      np.ndarray[floating, ndim=2] lat1,
+                                      np.ndarray[floating, ndim=2] a_track,
+                                      np.ndarray[floating, ndim=2] a_scan):
         res = []
         cdef np.ndarray[floating, ndim=3] lon1_3d, lat1_3d
         lon1_3d = lon1.reshape((-1, self._coarse_scan_length, self._coarse_scan_width))

--- a/geotiepoints/_modis_utils.pxd
+++ b/geotiepoints/_modis_utils.pxd
@@ -1,0 +1,22 @@
+cimport numpy as np
+
+ctypedef fused floating:
+    np.float32_t
+    np.float64_t
+
+cdef void lonlat2xyz(
+        floating[:, :, :] lons,
+        floating[:, :, :] lats,
+        floating[:, :, :, ::1] xyz,
+) nogil
+
+cdef void xyz2lonlat(
+        floating[:, :, ::1] xyz,
+        floating[:, ::1] lons,
+        floating[:, ::1] lats,
+        bint low_lat_z=*,
+        floating thr=*,
+) nogil
+
+cdef floating rad2deg(floating x) nogil
+cdef floating deg2rad(floating x) nogil

--- a/geotiepoints/_modis_utils.pyx
+++ b/geotiepoints/_modis_utils.pyx
@@ -1,0 +1,209 @@
+from functools import wraps
+
+cimport cython
+cimport numpy as np
+from libc.math cimport asin, sin, cos, sqrt, acos, M_PI
+import numpy as np
+
+try:
+    import dask.array as da
+except ImportError:
+    # if dask can't be imported then we aren't going to be given dask arrays
+    da = None
+
+try:
+    import xarray as xr
+except ImportError:
+    xr = None
+
+
+DEF EARTH_RADIUS = 6370997.0
+DEF R = 6371.0
+# Aqua scan width and altitude in km
+DEF scan_width = 10.00017
+DEF H = 705.0
+
+
+@cython.boundscheck(False)
+@cython.cdivision(True)
+@cython.wraparound(False)
+cdef void lonlat2xyz(
+        floating[:, :, :] lons,
+        floating[:, :, :] lats,
+        floating[:, :, :, ::1] xyz,
+) nogil:
+    """Convert lons and lats to cartesian coordinates."""
+    cdef Py_ssize_t i, j, k
+    cdef floating lon_rad, lat_rad
+    for i in range(lons.shape[0]):
+        for j in range(lons.shape[1]):
+            for k in range(lons.shape[2]):
+                lon_rad = deg2rad(lons[i, j, k])
+                lat_rad = deg2rad(lats[i, j, k])
+                xyz[i, j, k, 0] = EARTH_RADIUS * cos(lat_rad) * cos(lon_rad)
+                xyz[i, j, k, 1] = EARTH_RADIUS * cos(lat_rad) * sin(lon_rad)
+                xyz[i, j, k, 2] = EARTH_RADIUS * sin(lat_rad)
+
+
+@cython.boundscheck(False)
+@cython.cdivision(True)
+@cython.wraparound(False)
+cdef void xyz2lonlat(
+        floating[:, :, ::1] xyz,
+        floating[:, ::1] lons,
+        floating[:, ::1] lats,
+        bint low_lat_z=True,
+        floating thr=0.8) nogil:
+    """Get longitudes from cartesian coordinates."""
+    cdef Py_ssize_t i, j
+    cdef np.float64_t x, y, z
+    for i in range(xyz.shape[0]):
+        for j in range(xyz.shape[1]):
+            # 64-bit precision matters apparently
+            x = <np.float64_t>xyz[i, j, 0]
+            y = <np.float64_t>xyz[i, j, 1]
+            z = <np.float64_t>xyz[i, j, 2]
+            lons[i, j] = rad2deg(acos(x / sqrt(x ** 2 + y ** 2))) * _sign(y)
+            # if we are at low latitudes - small z, then get the
+            # latitudes only from z. If we are at high latitudes (close to the poles)
+            # then derive the latitude using x and y:
+            if low_lat_z and (z < thr * EARTH_RADIUS) and (z > -1.0 * thr * EARTH_RADIUS):
+                lats[i, j] = 90 - rad2deg(acos(z / EARTH_RADIUS))
+            else:
+                lats[i, j] = _sign(z) * (90 - rad2deg(asin(sqrt(x ** 2 + y ** 2) / EARTH_RADIUS)))
+
+
+cdef inline int _sign(floating x) nogil:
+    return 1 if x > 0 else (-1 if x < 0 else 0)
+
+
+cdef inline floating rad2deg(floating x) nogil:
+    return x * (180.0 / M_PI)
+
+
+cdef inline floating deg2rad(floating x) nogil:
+    return x * (M_PI / 180.0)
+
+
+
+def rows_per_scan_for_resolution(res):
+    return {
+        5000: 2,
+        1000: 10,
+        500: 20,
+        250: 40,
+    }[res]
+
+
+def scanline_mapblocks(func):
+    """Convert dask array inputs to appropriate map_blocks calls.
+
+    This function, applied as a decorator, will call the wrapped function
+    using dask's ``map_blocks``. It will rechunk dask array inputs when
+    necessary to make sure that the input chunks are entire scanlines to
+    avoid incorrect interpolation.
+
+    """
+    @wraps(func)
+    def _wrapper(*args, coarse_resolution=None, fine_resolution=None, **kwargs):
+        if coarse_resolution is None or fine_resolution is None:
+            raise ValueError("'coarse_resolution' and 'fine_resolution' are required keyword arguments.")
+        first_arr = [arr for arr in args if hasattr(arr, "ndim")][0]
+        if first_arr.ndim != 2 or first_arr.ndim != 2:
+            raise ValueError("Expected 2D input arrays.")
+        if hasattr(first_arr, "compute"):
+            # assume it is dask or xarray with dask, ensure proper chunk size
+            # if DataArray get just the dask array
+            dask_args = _extract_dask_arrays_from_args(args)
+            rows_per_scan = rows_per_scan_for_resolution(coarse_resolution)
+            rechunked_args = _rechunk_dask_arrays_if_needed(dask_args, rows_per_scan)
+            results = _call_map_blocks_interp(
+                func,
+                coarse_resolution,
+                fine_resolution,
+                *rechunked_args,
+                **kwargs
+            )
+            if hasattr(first_arr, "dims"):
+                # recreate DataArrays
+                results = _results_to_data_arrays(first_arr.dims, *results)
+            return results
+        return func(
+            *args,
+            coarse_resolution=coarse_resolution,
+            fine_resolution=fine_resolution,
+            **kwargs
+        )
+
+    return _wrapper
+
+
+def _extract_dask_arrays_from_args(args):
+    return [arr_obj.data if hasattr(arr_obj, "dims") else arr_obj for arr_obj in args]
+
+
+def _call_map_blocks_interp(func, coarse_resolution, fine_resolution, *args, **kwargs):
+    first_arr = [arr for arr in args if hasattr(arr, "ndim")][0]
+    res_factor = coarse_resolution // fine_resolution
+    new_row_chunks = tuple(x * res_factor for x in first_arr.chunks[0])
+    fine_pixels_per_1km = {250: 4, 500: 2, 1000: 1}[fine_resolution]
+    fine_scan_width = 1354 * fine_pixels_per_1km
+    new_col_chunks = (fine_scan_width,)
+    wrapped_func = _map_blocks_handler(func)
+    res = da.map_blocks(wrapped_func, *args,
+                        coarse_resolution=coarse_resolution,
+                        fine_resolution=fine_resolution,
+                        **kwargs,
+                        new_axis=[0],
+                        chunks=(2, new_row_chunks, new_col_chunks),
+                        dtype=first_arr.dtype,
+                        meta=np.empty((2, 2, 2), dtype=first_arr.dtype))
+    return tuple(res[idx] for idx in range(res.shape[0]))
+
+
+def _results_to_data_arrays(dims, *results):
+    new_results = []
+    for result in results:
+        if not isinstance(result, da.Array):
+            continue
+        data_arr = xr.DataArray(result, dims=dims)
+        new_results.append(data_arr)
+    return new_results
+
+
+def _rechunk_dask_arrays_if_needed(args, rows_per_scan: int):
+    # take current chunk size and get a relatively similar chunk size
+    first_arr = [arr for arr in args if hasattr(arr, "ndim")][0]
+    row_chunks = first_arr.chunks[0]
+    col_chunks = first_arr.chunks[1]
+    num_rows = first_arr.shape[0]
+    num_cols = first_arr.shape[-1]
+    good_row_chunks = all(x % rows_per_scan == 0 for x in row_chunks)
+    good_col_chunks = len(col_chunks) == 1 and col_chunks[0] != num_cols
+    all_orig_chunks = [arr.chunks for arr in args if hasattr(arr, "chunks")]
+
+    if num_rows % rows_per_scan != 0:
+        raise ValueError("Input longitude/latitude data does not consist of "
+                         "whole scans (10 rows per scan).")
+    all_same_chunks = all(
+        all_orig_chunks[0] == some_chunks
+        for some_chunks in all_orig_chunks[1:]
+    )
+    if good_row_chunks and good_col_chunks and all_same_chunks:
+        return args
+
+    new_row_chunks = (row_chunks[0] // rows_per_scan) * rows_per_scan
+    new_args = [arr.rechunk((new_row_chunks, -1)) if hasattr(arr, "chunks") else arr for arr in args]
+    return new_args
+
+
+def _map_blocks_handler(func):
+    @wraps(func)
+    def _map_blocks_wrapper(*args, **kwargs):
+        results = func(*args, **kwargs)
+        return np.concatenate(
+            tuple(result[np.newaxis] for result in results),
+            axis=0)
+    return _map_blocks_wrapper
+
+

--- a/geotiepoints/_simple_modis_interpolator.pyx
+++ b/geotiepoints/_simple_modis_interpolator.pyx
@@ -87,21 +87,26 @@ cdef void _compute_interpolated_xyz_scan(
 ) nogil:
     cdef Py_ssize_t comp_index
     cdef floating[:, :] input_view, result_view
-    for comp_index in range(3):
-        input_view = xyz_input_view[:, :, comp_index]
-        result_view = xyz_result_view[:, :, comp_index]
-        with gil:
+    with gil:
+        for comp_index in range(3):
+            input_view = xyz_input_view[:, :, comp_index]
+            result_view = xyz_result_view[:, :, comp_index]
             _call_map_coordinates(
                 input_view,
                 coordinates_view,
                 result_view,
             )
-        if res_factor == 4:
+
+    if res_factor == 4:
+        for comp_index in range(3):
+            result_view = xyz_result_view[:, :, comp_index]
             _interpolate_xyz_250(
                 result_view,
                 coordinates_view,
             )
-        else:
+    else:
+        for comp_index in range(3):
+            result_view = xyz_result_view[:, :, comp_index]
             _interpolate_xyz_500(
                 result_view,
                 coordinates_view,

--- a/geotiepoints/_simple_modis_interpolator.pyx
+++ b/geotiepoints/_simple_modis_interpolator.pyx
@@ -1,0 +1,113 @@
+cimport cython
+
+cimport numpy as np
+from scipy.ndimage.interpolation import map_coordinates
+from .geointerpolator import lonlat2xyz, xyz2lonlat
+from libc.math cimport asin, sin, cos, sqrt, acos, M_PI
+import numpy as np
+
+ctypedef fused floating:
+    np.float32_t
+    np.float64_t
+
+
+def rows_per_scan_for_resolution(res):
+    return {
+        5000: 2,
+        1000: 10,
+        500: 20,
+        250: 40,
+    }[res]
+
+
+def interpolate_geolocation_cartesian(
+        np.ndarray[floating, ndim=2] lon_array,
+        np.ndarray[floating, ndim=2] lat_array,
+        unsigned int coarse_resolution,
+        unsigned int fine_resolution):
+    cdef unsigned int rows_per_scan = rows_per_scan_for_resolution(coarse_resolution)
+    cdef unsigned int res_factor = coarse_resolution // fine_resolution
+    cdef Py_ssize_t num_rows = lon_array.shape[0]
+    cdef Py_ssize_t num_cols = lon_array.shape[1]
+    cdef unsigned int num_scans = num_rows // rows_per_scan
+    cdef np.ndarray[floating, ndim=2] x_in, y_in, z_in
+    # TODO: Use lon/lat views and cython version of lonlat2xyz
+    x_in, y_in, z_in = lonlat2xyz(lon_array, lat_array)
+
+    cdef np.ndarray[floating, ndim=3] coordinates = np.empty(
+        (2, res_factor * rows_per_scan, res_factor * num_cols), dtype=lon_array.dtype)
+    cdef floating[:, :, ::1] coordinates_view = coordinates
+    _compute_xy_coordinate_arrays(num_cols, res_factor, rows_per_scan, coordinates_view)
+
+    new_x = np.empty((num_rows * res_factor, num_cols * res_factor), dtype=lon_array.dtype)
+    new_y = new_x.copy()
+    new_z = new_x.copy()
+    nav_arrays = [(x_in, new_x), (y_in, new_y), (z_in, new_z)]
+
+    # Interpolate each scan, one at a time, otherwise the math doesn't work well
+    for scan_idx in range(num_scans):
+        # Calculate indexes
+        j0 = rows_per_scan * scan_idx
+        j1 = j0 + rows_per_scan
+        k0 = rows_per_scan * res_factor * scan_idx
+        k1 = k0 + rows_per_scan * res_factor
+
+        for nav_array, result_array in nav_arrays:
+            # Use bilinear interpolation for all 250 meter pixels
+            map_coordinates(nav_array[j0:j1, :], coordinates, output=result_array[k0:k1, :], order=1, mode='nearest')
+
+            if res_factor == 4:
+                # Use linear extrapolation for the first two 250 meter pixels along track
+                m, b = _calc_slope_offset_250(result_array, coordinates[0], k0, 2)
+                result_array[k0 + 0, :] = m * coordinates[0, 0, 0] + b
+                result_array[k0 + 1, :] = m * coordinates[0, 1, 0] + b
+
+                # Use linear extrapolation for the last  two 250 meter pixels along track
+                # m = (result_array[k0 + 37, :] - result_array[k0 + 34, :]) / (y[37, 0] - y[34, 0])
+                # b = result_array[k0 + 37, :] - m * y[37, 0]
+                m, b = _calc_slope_offset_250(result_array, coordinates[0], k0, 34)
+                result_array[k0 + 38, :] = m * coordinates[0, 38, 0] + b
+                result_array[k0 + 39, :] = m * coordinates[0, 39, 0] + b
+            else:
+                # 500m
+                # Use linear extrapolation for the first two 250 meter pixels along track
+                m, b = _calc_slope_offset_500(result_array, coordinates[0], k0, 1)
+                result_array[k0 + 0, :] = m * coordinates[0, 0, 0] + b
+
+                # Use linear extrapolation for the last two 250 meter pixels along track
+                m, b = _calc_slope_offset_500(result_array, coordinates[0], k0, 17)
+                result_array[k0 + 19, :] = m * coordinates[0, 19, 0] + b
+
+    new_lons, new_lats = xyz2lonlat(new_x, new_y, new_z, low_lat_z=True)
+    return new_lons.astype(lon_array.dtype), new_lats.astype(lon_array.dtype)
+
+
+cdef void _compute_xy_coordinate_arrays(
+        Py_ssize_t num_cols,
+        unsigned int res_factor,
+        unsigned int rows_per_scan,
+        floating[:, :, ::1] coordinates,
+) nogil:
+    cdef Py_ssize_t i, j
+    for j in range(coordinates.shape[1]):
+        for i in range(coordinates.shape[2]):
+            # y coordinate - 0.375 for 250m, 0.25 for 500m
+            coordinates[0, j, i] = j * (1.0 / res_factor) - (res_factor * (1.0 / 16) + (1.0 / 8))
+            # x coordinate
+            coordinates[1, j, i] = i * (1.0 / res_factor)
+
+
+def _calc_slope_offset_250(result_array, y, start_idx, offset):
+    m = (result_array[start_idx + offset + 3, :] - result_array[start_idx + offset, :]) / \
+        (y[offset + 3, 0] - y[offset, 0])
+    b = result_array[start_idx + offset + 3, :] - m * y[offset + 3, 0]
+    return m, b
+
+
+def _calc_slope_offset_500(result_array, y, start_idx, offset):
+    m = (result_array[start_idx + offset + 1, :] - result_array[start_idx + offset, :]) / \
+        (y[offset + 1, 0] - y[offset, 0])
+    b = result_array[start_idx + offset + 1, :] - m * y[offset + 1, 0]
+    return m, b
+
+

--- a/geotiepoints/modisinterpolator.py
+++ b/geotiepoints/modisinterpolator.py
@@ -27,246 +27,31 @@ Compact VIIRS SDR Product Format User Guide (V1J)
 http://www.eumetsat.int/website/wcm/idc/idcplg?IdcService=GET_FILE&dDocName=PDF_DMT_708025&RevisionSelectionMethod=LatestReleased&Rendition=Web
 """
 
-import numpy as np
 import warnings
 
-from .geointerpolator import lonlat2xyz, xyz2lonlat
-from .simple_modis_interpolator import scanline_mapblocks
-
-R = 6371.0
-# Aqua scan width and altitude in km
-scan_width = 10.00017
-H = 705.0
-
-
-def _compute_phi(zeta):
-    return np.arcsin(R * np.sin(zeta) / (R + H))
-
-
-def _compute_theta(zeta, phi):
-    return zeta - phi
-
-
-def _compute_zeta(phi):
-    return np.arcsin((R + H) * np.sin(phi) / R)
-
-
-def _compute_expansion_alignment(satz_a, satz_b):
-    """All angles in radians."""
-    zeta_a = satz_a
-    zeta_b = satz_b
-
-    phi_a = _compute_phi(zeta_a)
-    phi_b = _compute_phi(zeta_b)
-    theta_a = _compute_theta(zeta_a, phi_a)
-    theta_b = _compute_theta(zeta_b, phi_b)
-    phi = (phi_a + phi_b) / 2
-    zeta = _compute_zeta(phi)
-    theta = _compute_theta(zeta, phi)
-    # Workaround for tiepoints symetrical about the subsatellite-track
-    denominator = np.where(theta_a == theta_b, theta_a * 2, theta_a - theta_b)
-
-    c_expansion = 4 * (((theta_a + theta_b) / 2 - theta) / denominator)
-
-    sin_beta_2 = scan_width / (2 * H)
-
-    d = ((R + H) / R * np.cos(phi) - np.cos(zeta)) * sin_beta_2
-    e = np.cos(zeta) - np.sqrt(np.cos(zeta) ** 2 - d ** 2)
-
-    c_alignment = 4 * e * np.sin(zeta) / denominator
-
-    return c_expansion, c_alignment
-
-
-def _get_corners(arr):
-    arr_a = arr[:, :-1, :-1]
-    arr_b = arr[:, :-1, 1:]
-    arr_c = arr[:, 1:, 1:]
-    arr_d = arr[:, 1:, :-1]
-    return arr_a, arr_b, arr_c, arr_d
-
-
-@scanline_mapblocks
-def _interpolate(
-        lon1,
-        lat1,
-        satz1,
-        coarse_resolution=None,
-        fine_resolution=None,
-        coarse_scan_width=None,
-):
-    """Helper function to interpolate scan-aligned arrays.
-
-    This function's decorator runs this function for each dask block/chunk of
-    scans. The arrays are scan-aligned meaning they are an even number of scans
-    (N rows per scan) and contain the entire scan width.
-
-    """
-    interp = _Interpolator(coarse_resolution, fine_resolution, coarse_scan_width=coarse_scan_width)
-    return interp.interpolate(lon1, lat1, satz1)
-
-
-class _Interpolator:
-    """Helper class for MODIS interpolation.
-
-    Not intended for public use. Use ``modis_X_to_Y`` functions instead.
-
-    """
-    def __init__(self, coarse_resolution, fine_resolution, coarse_scan_width=None):
-        if coarse_resolution == 1000:
-            coarse_scan_length = 10
-            coarse_scan_width = 1354
-            self._get_coords = self._get_coords_1km
-            self._expand_tiepoint_array = self._expand_tiepoint_array_1km
-        elif coarse_resolution == 5000:
-            coarse_scan_length = 2
-            self._get_coords = self._get_coords_5km
-            self._expand_tiepoint_array = self._expand_tiepoint_array_5km
-            if coarse_scan_width is None:
-                coarse_scan_width = 271
-            else:
-                coarse_scan_width = coarse_scan_width
-        self._coarse_scan_length = coarse_scan_length
-        self._coarse_scan_width = coarse_scan_width
-        self._coarse_pixels_per_1km = coarse_resolution // 1000
-
-        fine_pixels_per_1km = {
-            250: 4,
-            500: 2,
-            1000: 1,
-        }[fine_resolution]
-        self._fine_pixels_per_coarse_pixel = fine_pixels_per_1km * self._coarse_pixels_per_1km
-        self._fine_scan_width = 1354 * fine_pixels_per_1km
-        self._fine_scan_length = fine_pixels_per_1km * 10 // coarse_scan_length
-        self._coarse_resolution = coarse_resolution
-        self._fine_resolution = fine_resolution
-
-    def interpolate(self, lon1, lat1, satz1):
-        """Interpolate MODIS geolocation from 'coarse_resolution' to 'fine_resolution'."""
-        scans = satz1.shape[0] // self._coarse_scan_length
-        # reshape to (num scans, rows per scan, columns per scan)
-        satz1 = satz1.reshape((-1, self._coarse_scan_length, self._coarse_scan_width))
-
-        satz_a, satz_b = _get_corners(np.deg2rad(satz1))[:2]
-        c_exp, c_ali = _compute_expansion_alignment(satz_a, satz_b)
-
-        x, y = self._get_coords(scans)
-        i_rs, i_rt = np.meshgrid(x, y)
-
-        p_os = 0
-        p_ot = 0
-        s_s = (p_os + i_rs) * 1.0 / self._fine_pixels_per_coarse_pixel
-        s_t = (p_ot + i_rt) * 1.0 / self._fine_scan_length
-
-        c_exp_full = self._expand_tiepoint_array(c_exp)
-        c_ali_full = self._expand_tiepoint_array(c_ali)
-
-        a_track = s_t
-        a_scan = s_s + s_s * (1 - s_s) * c_exp_full + s_t * (1 - s_t) * c_ali_full
-
-        res = []
-        datasets = lonlat2xyz(lon1, lat1)
-        for data in datasets:
-            data = data.reshape((-1, self._coarse_scan_length, self._coarse_scan_width))
-            data_a, data_b, data_c, data_d = _get_corners(data)
-            data_a = self._expand_tiepoint_array(data_a)
-            data_b = self._expand_tiepoint_array(data_b)
-            data_c = self._expand_tiepoint_array(data_c)
-            data_d = self._expand_tiepoint_array(data_d)
-
-            data_1 = (1 - a_scan) * data_a + a_scan * data_b
-            data_2 = (1 - a_scan) * data_d + a_scan * data_c
-            data = (1 - a_track) * data_1 + a_track * data_2
-
-            res.append(data)
-        new_lons, new_lats = xyz2lonlat(*res)
-        return new_lons.astype(lon1.dtype), new_lats.astype(lat1.dtype)
-
-    def _get_coords_1km(self, scans):
-        y = (
-            np.arange((self._coarse_scan_length + 1) * self._fine_scan_length) % self._fine_scan_length
-        ) + 0.5
-        half_scan_length = self._fine_scan_length // 2
-        y = y[half_scan_length:-half_scan_length]
-        y[:half_scan_length] = np.arange(-self._fine_scan_length / 2 + 0.5, 0)
-        y[-half_scan_length:] = np.arange(self._fine_scan_length + 0.5, self._fine_scan_length * 3 / 2)
-        y = np.tile(y, scans)
-
-        x = np.arange(self._fine_scan_width) % self._fine_pixels_per_coarse_pixel
-        x[-self._fine_pixels_per_coarse_pixel:] = np.arange(
-            self._fine_pixels_per_coarse_pixel,
-            self._fine_pixels_per_coarse_pixel * 2)
-        return x, y
-
-    def _get_coords_5km(self, scans):
-        y = np.arange(self._fine_scan_length * self._coarse_scan_length) - 2
-        y = np.tile(y, scans)
-
-        x = (np.arange(self._fine_scan_width) - 2) % self._fine_pixels_per_coarse_pixel
-        x[0] = -2
-        x[1] = -1
-        if self._coarse_scan_width == 271:
-            x[-2] = 5
-            x[-1] = 6
-        elif self._coarse_scan_width == 270:
-            x[-7] = 5
-            x[-6] = 6
-            x[-5] = 7
-            x[-4] = 8
-            x[-3] = 9
-            x[-2] = 10
-            x[-1] = 11
-        else:
-            raise NotImplementedError(
-                "Can't interpolate if 5km tiepoints have less than 270 columns."
-            )
-        return x, y
-
-    def _expand_tiepoint_array_1km(self, arr):
-        arr = np.repeat(arr, self._fine_scan_length, axis=1)
-        arr = np.concatenate(
-            (arr[:, :self._fine_scan_length // 2, :], arr, arr[:, -(self._fine_scan_length // 2):, :]), axis=1
-        )
-        arr = np.repeat(arr.reshape((-1, self._coarse_scan_width - 1)), self._fine_pixels_per_coarse_pixel, axis=1)
-        return np.hstack((arr, arr[:, -self._fine_pixels_per_coarse_pixel:]))
-
-    def _expand_tiepoint_array_5km(self, arr):
-        arr = np.repeat(arr, self._fine_scan_length * 2, axis=1)
-        arr = np.repeat(arr.reshape((-1, self._coarse_scan_width - 1)), self._fine_pixels_per_coarse_pixel, axis=1)
-        factor = self._fine_pixels_per_coarse_pixel // self._coarse_pixels_per_1km
-        if self._coarse_scan_width == 271:
-            return np.hstack((arr[:, :2 * factor], arr, arr[:, -2 * factor:]))
-        else:
-            return np.hstack(
-                (
-                    arr[:, :2 * factor],
-                    arr,
-                    arr[:, -self._fine_pixels_per_coarse_pixel:],
-                    arr[:, -2 * factor:],
-                )
-            )
+from ._modis_interpolator import interpolate
 
 
 def modis_1km_to_250m(lon1, lat1, satz1):
     """Interpolate MODIS geolocation from 1km to 250m resolution."""
-    return _interpolate(lon1, lat1, satz1,
-                        coarse_resolution=1000,
-                        fine_resolution=250)
+    return interpolate(lon1, lat1, satz1,
+                       coarse_resolution=1000,
+                       fine_resolution=250)
 
 
 def modis_1km_to_500m(lon1, lat1, satz1):
     """Interpolate MODIS geolocation from 1km to 500m resolution."""
-    return _interpolate(lon1, lat1, satz1,
-                        coarse_resolution=1000,
-                        fine_resolution=500)
+    return interpolate(lon1, lat1, satz1,
+                       coarse_resolution=1000,
+                       fine_resolution=500)
 
 
 def modis_5km_to_1km(lon1, lat1, satz1):
     """Interpolate MODIS geolocation from 5km to 1km resolution."""
-    return _interpolate(lon1, lat1, satz1,
-                        coarse_resolution=5000,
-                        fine_resolution=1000,
-                        coarse_scan_width=lon1.shape[1])
+    return interpolate(lon1, lat1, satz1,
+                       coarse_resolution=5000,
+                       fine_resolution=1000,
+                       coarse_scan_width=lon1.shape[1])
 
 
 def modis_5km_to_500m(lon1, lat1, satz1):
@@ -274,10 +59,10 @@ def modis_5km_to_500m(lon1, lat1, satz1):
     warnings.warn(
         "Interpolating 5km geolocation to 500m resolution " "may result in poor quality"
     )
-    return _interpolate(lon1, lat1, satz1,
-                        coarse_resolution=5000,
-                        fine_resolution=500,
-                        coarse_scan_width=lon1.shape[1])
+    return interpolate(lon1, lat1, satz1,
+                       coarse_resolution=5000,
+                       fine_resolution=500,
+                       coarse_scan_width=lon1.shape[1])
 
 
 def modis_5km_to_250m(lon1, lat1, satz1):
@@ -285,7 +70,7 @@ def modis_5km_to_250m(lon1, lat1, satz1):
     warnings.warn(
         "Interpolating 5km geolocation to 250m resolution " "may result in poor quality"
     )
-    return _interpolate(lon1, lat1, satz1,
-                        coarse_resolution=5000,
-                        fine_resolution=250,
-                        coarse_scan_width=lon1.shape[1])
+    return interpolate(lon1, lat1, satz1,
+                       coarse_resolution=5000,
+                       fine_resolution=250,
+                       coarse_scan_width=lon1.shape[1])

--- a/geotiepoints/modisinterpolator.py
+++ b/geotiepoints/modisinterpolator.py
@@ -125,7 +125,6 @@ def _interpolate(
             coarse_scan_width = coarse_scan_width
     coarse_pixels_per_1km = coarse_resolution // 1000
 
-    res_factor = coarse_resolution // fine_resolution
     fine_pixels_per_1km = {
         250: 4,
         500: 2,

--- a/geotiepoints/modisinterpolator.py
+++ b/geotiepoints/modisinterpolator.py
@@ -107,11 +107,6 @@ class ModisInterpolator:
             500: 2,
             1000: 1,
         }[fine_resolution]
-        # course == 5km, fine == 500 -> 2 * 5 = 10
-        # equivalent to course // fine?
-        # course == 5km, fine == 250 -> 4 * 5 = 20
-        # course == 1km, fine == 500 -> 2 * 1 = 2
-        # course == 1km, fine == 1km -> 1 * 1 = 1
         self.fine_pixels_per_course_pixel = (
             fine_pixels_per_1km * self._course_pixels_per_1km
         )

--- a/geotiepoints/modisinterpolator.py
+++ b/geotiepoints/modisinterpolator.py
@@ -96,8 +96,12 @@ class _Interpolator:
         if coarse_resolution == 1000:
             coarse_scan_length = 10
             coarse_scan_width = 1354
+            self._get_coords = self._get_coords_1km
+            self._expand_tiepoint_array = self._expand_tiepoint_array_1km
         elif coarse_resolution == 5000:
             coarse_scan_length = 2
+            self._get_coords = self._get_coords_5km
+            self._expand_tiepoint_array = self._expand_tiepoint_array_5km
             if coarse_scan_width is None:
                 coarse_scan_width = 271
             else:
@@ -114,12 +118,6 @@ class _Interpolator:
         self._fine_pixels_per_coarse_pixel = fine_pixels_per_1km * self._coarse_pixels_per_1km
         self._fine_scan_width = 1354 * fine_pixels_per_1km
         self._fine_scan_length = fine_pixels_per_1km * 10 // coarse_scan_length
-        if coarse_resolution == 1000:
-            self._get_coords = self._get_coords_1km
-            self._expand_tiepoint_array = self._expand_tiepoint_array_1km
-        else:
-            self._get_coords = self._get_coords_5km
-            self._expand_tiepoint_array = self._expand_tiepoint_array_5km
         self._coarse_resolution = coarse_resolution
         self._fine_resolution = fine_resolution
 

--- a/geotiepoints/modisinterpolator.py
+++ b/geotiepoints/modisinterpolator.py
@@ -160,7 +160,6 @@ def _interpolate(
 
     p_os = 0
     p_ot = 0
-
     s_s = (p_os + i_rs) * 1.0 / fine_pixels_per_coarse_pixel
     s_t = (p_ot + i_rt) * 1.0 / fine_scan_length
 
@@ -283,11 +282,11 @@ def _expand_tiepoint_array_1km(
     coarse_scan_width,
     fine_pixels_per_coarse_pixel,
     arr,
-    find_scan_length,
+    fine_scan_length,
 ):
-    arr = np.repeat(arr, find_scan_length, axis=1)
+    arr = np.repeat(arr, fine_scan_length, axis=1)
     arr = np.concatenate(
-        (arr[:, : find_scan_length // 2, :], arr, arr[:, -(find_scan_length // 2):, :]), axis=1
+        (arr[:, : fine_scan_length // 2, :], arr, arr[:, -(fine_scan_length // 2):, :]), axis=1
     )
     arr = np.repeat(arr.reshape((-1, coarse_scan_width - 1)), fine_pixels_per_coarse_pixel, axis=1)
     return np.hstack((arr, arr[:, -fine_pixels_per_coarse_pixel:]))

--- a/geotiepoints/modisinterpolator.py
+++ b/geotiepoints/modisinterpolator.py
@@ -51,7 +51,7 @@ def _compute_zeta(phi):
     return np.arcsin((R + H) * np.sin(phi) / R)
 
 
-def _compute_expansion_alignment(satz_a, satz_b, satz_c, satz_d):
+def _compute_expansion_alignment(satz_a, satz_b):
     """All angles in radians."""
     zeta_a = satz_a
     zeta_b = satz_b
@@ -125,9 +125,9 @@ def _interpolate(
     # reshape to (num scans, rows per scan, columns per scan)
     satz1 = satz1.reshape((-1, coarse_scan_length, coarse_scan_width))
 
-    satz_a, satz_b, satz_c, satz_d = _get_corners(np.deg2rad(satz1))
+    satz_a, satz_b = _get_corners(np.deg2rad(satz1))[:2]
 
-    c_exp, c_ali = _compute_expansion_alignment(satz_a, satz_b, satz_c, satz_d)
+    c_exp, c_ali = _compute_expansion_alignment(satz_a, satz_b)
 
     x, y = get_coords(
         coarse_scan_length,

--- a/geotiepoints/modisinterpolator.py
+++ b/geotiepoints/modisinterpolator.py
@@ -40,30 +40,30 @@ scan_width = 10.00017
 H = 705.
 
 
-def compute_phi(zeta):
+def _compute_phi(zeta):
     return np.arcsin(R * np.sin(zeta) / (R + H))
 
 
-def compute_theta(zeta, phi):
+def _compute_theta(zeta, phi):
     return zeta - phi
 
 
-def compute_zeta(phi):
+def _compute_zeta(phi):
     return np.arcsin((R + H) * np.sin(phi) / R)
 
 
-def compute_expansion_alignment(satz_a, satz_b, satz_c, satz_d):
+def _compute_expansion_alignment(satz_a, satz_b, satz_c, satz_d):
     """All angles in radians."""
     zeta_a = satz_a
     zeta_b = satz_b
 
-    phi_a = compute_phi(zeta_a)
-    phi_b = compute_phi(zeta_b)
-    theta_a = compute_theta(zeta_a, phi_a)
-    theta_b = compute_theta(zeta_b, phi_b)
+    phi_a = _compute_phi(zeta_a)
+    phi_b = _compute_phi(zeta_b)
+    theta_a = _compute_theta(zeta_a, phi_a)
+    theta_b = _compute_theta(zeta_b, phi_b)
     phi = (phi_a + phi_b) / 2
-    zeta = compute_zeta(phi)
-    theta = compute_theta(zeta, phi)
+    zeta = _compute_zeta(phi)
+    theta = _compute_theta(zeta, phi)
     # Workaround for tiepoints symetrical about the subsatellite-track
     denominator = np.where(theta_a == theta_b, theta_a * 2, theta_a - theta_b)
 
@@ -79,7 +79,7 @@ def compute_expansion_alignment(satz_a, satz_b, satz_c, satz_d):
     return c_expansion, c_alignment
 
 
-def get_corners(arr):
+def _get_corners(arr):
     arr_a = arr[:, :-1, :-1]
     arr_b = arr[:, :-1, 1:]
     arr_c = arr[:, 1:, 1:]
@@ -156,9 +156,9 @@ def _interpolate(
     scans = satz1.shape[0] // cscan_len
     satz1 = satz1.reshape((-1, cscan_len, cscan_full_width))
 
-    satz_a, satz_b, satz_c, satz_d = get_corners(np.deg2rad(satz1))
+    satz_a, satz_b, satz_c, satz_d = _get_corners(np.deg2rad(satz1))
 
-    c_exp, c_ali = compute_expansion_alignment(satz_a, satz_b, satz_c, satz_d)
+    c_exp, c_ali = _compute_expansion_alignment(satz_a, satz_b, satz_c, satz_d)
 
     x, y = get_coords(cscan_len, cscan_full_width, fscan_len, fscan_width, fscan_full_width, scans)
     i_rs, i_rt = np.meshgrid(x, y)
@@ -182,7 +182,7 @@ def _interpolate(
     datasets = lonlat2xyz(lon1, lat1)
     for data in datasets:
         data = data.reshape((-1, cscan_len, cscan_full_width))
-        data_a, data_b, data_c, data_d = get_corners(data)
+        data_a, data_b, data_c, data_d = _get_corners(data)
         data_a = expand_tiepoint_array(cscan_width, cscan_full_width, fscan_width, data_a, lines, cols)
         data_b = expand_tiepoint_array(cscan_width, cscan_full_width, fscan_width, data_b, lines, cols)
         data_c = expand_tiepoint_array(cscan_width, cscan_full_width, fscan_width, data_c, lines, cols)

--- a/geotiepoints/simple_modis_interpolator.py
+++ b/geotiepoints/simple_modis_interpolator.py
@@ -106,7 +106,6 @@ def _extract_dask_arrays_from_args(args):
     return [arr_obj.data if hasattr(arr_obj, "dims") else arr_obj for arr_obj in args]
 
 
-
 def _call_map_blocks_interp(func, coarse_resolution, fine_resolution, *args, **kwargs):
     first_arr = [arr for arr in args if hasattr(arr, "ndim")][0]
     res_factor = coarse_resolution // fine_resolution

--- a/geotiepoints/simple_modis_interpolator.py
+++ b/geotiepoints/simple_modis_interpolator.py
@@ -32,135 +32,8 @@ in these files.
 
 """
 
-from functools import wraps
-
-import numpy as np
-from scipy.ndimage.interpolation import map_coordinates
-from .geointerpolator import lonlat2xyz, xyz2lonlat
-from . import _simple_modis_interpolator
-
-try:
-    import dask.array as da
-except ImportError:
-    # if dask can't be imported then we aren't going to be given dask arrays
-    da = None
-
-try:
-    import xarray as xr
-except ImportError:
-    xr = None
-
-
-def scanline_mapblocks(func):
-    """Convert dask array inputs to appropriate map_blocks calls.
-
-    This function, applied as a decorator, will call the wrapped function
-    using dask's ``map_blocks``. It will rechunk dask array inputs when
-    necessary to make sure that the input chunks are entire scanlines to
-    avoid incorrect interpolation.
-
-    """
-    @wraps(func)
-    def _wrapper(*args, coarse_resolution=None, fine_resolution=None, **kwargs):
-        if coarse_resolution is None or fine_resolution is None:
-            raise ValueError("'coarse_resolution' and 'fine_resolution' are required keyword arguments.")
-        first_arr = [arr for arr in args if hasattr(arr, "ndim")][0]
-        if first_arr.ndim != 2 or first_arr.ndim != 2:
-            raise ValueError("Expected 2D input arrays.")
-        if hasattr(first_arr, "compute"):
-            # assume it is dask or xarray with dask, ensure proper chunk size
-            # if DataArray get just the dask array
-            dask_args = _extract_dask_arrays_from_args(args)
-            rows_per_scan = _simple_modis_interpolator.rows_per_scan_for_resolution(coarse_resolution)
-            rechunked_args = _rechunk_dask_arrays_if_needed(dask_args, rows_per_scan)
-            results = _call_map_blocks_interp(
-                func,
-                coarse_resolution,
-                fine_resolution,
-                *rechunked_args,
-                **kwargs
-            )
-            if hasattr(first_arr, "dims"):
-                # recreate DataArrays
-                results = _results_to_data_arrays(first_arr.dims, *results)
-            return results
-        return func(
-            *args,
-            coarse_resolution=coarse_resolution,
-            fine_resolution=fine_resolution,
-            **kwargs
-        )
-
-    return _wrapper
-
-
-def _extract_dask_arrays_from_args(args):
-    return [arr_obj.data if hasattr(arr_obj, "dims") else arr_obj for arr_obj in args]
-
-
-def _call_map_blocks_interp(func, coarse_resolution, fine_resolution, *args, **kwargs):
-    first_arr = [arr for arr in args if hasattr(arr, "ndim")][0]
-    res_factor = coarse_resolution // fine_resolution
-    new_row_chunks = tuple(x * res_factor for x in first_arr.chunks[0])
-    fine_pixels_per_1km = {250: 4, 500: 2, 1000: 1}[fine_resolution]
-    fine_scan_width = 1354 * fine_pixels_per_1km
-    new_col_chunks = (fine_scan_width,)
-    wrapped_func = _map_blocks_handler(func)
-    res = da.map_blocks(wrapped_func, *args,
-                        coarse_resolution=coarse_resolution,
-                        fine_resolution=fine_resolution,
-                        **kwargs,
-                        new_axis=[0],
-                        chunks=(2, new_row_chunks, new_col_chunks),
-                        dtype=first_arr.dtype,
-                        meta=np.empty((2, 2, 2), dtype=first_arr.dtype))
-    return tuple(res[idx] for idx in range(res.shape[0]))
-
-
-def _results_to_data_arrays(dims, *results):
-    new_results = []
-    for result in results:
-        if not isinstance(result, da.Array):
-            continue
-        data_arr = xr.DataArray(result, dims=dims)
-        new_results.append(data_arr)
-    return new_results
-
-
-def _rechunk_dask_arrays_if_needed(args, rows_per_scan: int):
-    # take current chunk size and get a relatively similar chunk size
-    first_arr = [arr for arr in args if hasattr(arr, "ndim")][0]
-    row_chunks = first_arr.chunks[0]
-    col_chunks = first_arr.chunks[1]
-    num_rows = first_arr.shape[0]
-    num_cols = first_arr.shape[-1]
-    good_row_chunks = all(x % rows_per_scan == 0 for x in row_chunks)
-    good_col_chunks = len(col_chunks) == 1 and col_chunks[0] != num_cols
-    all_orig_chunks = [arr.chunks for arr in args if hasattr(arr, "chunks")]
-
-    if num_rows % rows_per_scan != 0:
-        raise ValueError("Input longitude/latitude data does not consist of "
-                         "whole scans (10 rows per scan).")
-    all_same_chunks = all(
-        all_orig_chunks[0] == some_chunks
-        for some_chunks in all_orig_chunks[1:]
-    )
-    if good_row_chunks and good_col_chunks and all_same_chunks:
-        return args
-
-    new_row_chunks = (row_chunks[0] // rows_per_scan) * rows_per_scan
-    new_args = [arr.rechunk((new_row_chunks, -1)) if hasattr(arr, "chunks") else arr for arr in args]
-    return new_args
-
-
-def _map_blocks_handler(func):
-    @wraps(func)
-    def _map_blocks_wrapper(*args, **kwargs):
-        results = func(*args, **kwargs)
-        return np.concatenate(
-            tuple(result[np.newaxis] for result in results),
-            axis=0)
-    return _map_blocks_wrapper
+from ._modis_utils import scanline_mapblocks
+from ._simple_modis_interpolator import interpolate_geolocation_cartesian as interp_cython
 
 
 @scanline_mapblocks
@@ -182,23 +55,9 @@ def interpolate_geolocation_cartesian(lon_array, lat_array, coarse_resolution, f
         A two-element tuple (lon, lat).
 
     """
-    return _simple_modis_interpolator.interpolate_geolocation_cartesian(
+    return interp_cython(
         lon_array, lat_array, coarse_resolution, fine_resolution
     )
-
-
-def _calc_slope_offset_250(result_array, y, start_idx, offset):
-    m = (result_array[start_idx + offset + 3, :] - result_array[start_idx + offset, :]) / \
-        (y[offset + 3, 0] - y[offset, 0])
-    b = result_array[start_idx + offset + 3, :] - m * y[offset + 3, 0]
-    return m, b
-
-
-def _calc_slope_offset_500(result_array, y, start_idx, offset):
-    m = (result_array[start_idx + offset + 1, :] - result_array[start_idx + offset, :]) / \
-        (y[offset + 1, 0] - y[offset, 0])
-    b = result_array[start_idx + offset + 1, :] - m * y[offset + 1, 0]
-    return m, b
 
 
 def modis_1km_to_250m(lon1, lat1):

--- a/geotiepoints/tests/test_modisinterpolator.py
+++ b/geotiepoints/tests/test_modisinterpolator.py
@@ -50,34 +50,34 @@ class TestModisInterpolator(unittest.TestCase):
         lat500 = to_da(h5f['lat_500m'])
 
         lons, lats = modis_1km_to_250m(lon1, lat1, satz1)
-        self.assertTrue(np.allclose(lon250, lons, atol=1e-2))
-        self.assertTrue(np.allclose(lat250, lats, atol=1e-2))
+        np.testing.assert_allclose(lon250, lons, atol=1e-2)
+        np.testing.assert_allclose(lat250, lats, atol=1e-2)
 
         lons, lats = modis_1km_to_500m(lon1, lat1, satz1)
-        self.assertTrue(np.allclose(lon500, lons, atol=1e-2))
-        self.assertTrue(np.allclose(lat500, lats, atol=1e-2))
+        np.testing.assert_allclose(lon500, lons, atol=1e-2)
+        np.testing.assert_allclose(lat500, lats, atol=1e-2)
 
         lat5 = lat1[2::5, 2::5]
         lon5 = lon1[2::5, 2::5]
 
         satz5 = satz1[2::5, 2::5]
         lons, lats = modis_5km_to_1km(lon5, lat5, satz5)
-        self.assertTrue(np.allclose(lon1, lons, atol=1e-2))
-        self.assertTrue(np.allclose(lat1, lats, atol=1e-2))
+        np.testing.assert_allclose(lon1, lons, atol=1e-2)
+        np.testing.assert_allclose(lat1, lats, atol=1e-2)
 
         # 5km to 500m
         lons, lats = modis_5km_to_500m(lon5, lat5, satz5)
         self.assertEqual(lon500.shape, lons.shape)
         self.assertEqual(lat500.shape, lats.shape)
-        # self.assertTrue(np.allclose(lon500, lons, atol=1e-2))
-        # self.assertTrue(np.allclose(lat500, lats, atol=1e-2))
+        # np.testing.assert_allclose(lon500, lons, atol=1e-2)
+        # np.testing.assert_allclose(lat500, lats, atol=1e-2)
 
         # 5km to 250m
         lons, lats = modis_5km_to_250m(lon5, lat5, satz5)
         self.assertEqual(lon250.shape, lons.shape)
         self.assertEqual(lat250.shape, lats.shape)
-        # self.assertTrue(np.allclose(lon250, lons, atol=1e-2))
-        # self.assertTrue(np.allclose(lat250, lats, atol=1e-2))
+        # np.testing.assert_allclose(lon250, lons, atol=1e-2)
+        # np.testing.assert_allclose(lat250, lats, atol=1e-2)
 
         # Test level 2
         lat5 = lat1[2::5, 2:-5:5]
@@ -85,11 +85,11 @@ class TestModisInterpolator(unittest.TestCase):
 
         satz5 = satz1[2::5, 2:-5:5]
         lons, lats = modis_5km_to_1km(lon5, lat5, satz5)
-        self.assertTrue(np.allclose(lon1, lons, atol=1e-2))
-        self.assertTrue(np.allclose(lat1, lats, atol=1e-2))
+        np.testing.assert_allclose(lon1, lons, atol=1e-2)
+        np.testing.assert_allclose(lat1, lats, atol=1e-2)
 
         # Test nans issue (#19)
-        satz1 = to_da(abs(np.linspace(-65.4, 65.4, 1354)).repeat(20).reshape(-1, 20).T)
+        satz1 = to_da(abs(np.linspace(-65.4, 65.4, 1354, dtype=np.float32)).repeat(20).reshape(-1, 20).T)
         lons, lats = modis_1km_to_500m(lon1, lat1, satz1)
         self.assertFalse(np.any(np.isnan(lons.compute())))
         self.assertFalse(np.any(np.isnan(lats.compute())))
@@ -110,5 +110,5 @@ class TestModisInterpolator(unittest.TestCase):
         lons, lats = modis_5km_to_1km(lon5, lat5, satz5)
         lons = lons + 180
         lons = xr.where(lons > 180, lons - 360, lons)
-        self.assertTrue(np.allclose(orig_lon, lons, atol=1e-2))
-        self.assertTrue(np.allclose(lat1, lats, atol=1e-2))
+        np.testing.assert_allclose(orig_lon, lons, atol=1e-2)
+        np.testing.assert_allclose(lat1, lats, atol=1e-2)

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,12 @@ EXTENSIONS = [
         extra_compile_args=extra_compile_args,
         include_dirs=[np.get_include()],
     ),
+    Extension(
+        'geotiepoints._modis_interpolator',
+        sources=['geotiepoints/_modis_interpolator.pyx'],
+        extra_compile_args=extra_compile_args,
+        include_dirs=[np.get_include()],
+    ),
 ]
 
 cmdclass = versioneer.get_cmdclass()
@@ -70,7 +76,7 @@ if __name__ == "__main__":
           python_requires='>=3.6',
           cmdclass=cmdclass,
           install_requires=requirements,
-          ext_modules=cythonize(EXTENSIONS),
+          ext_modules=cythonize(EXTENSIONS, compiler_directives={'language_level': '3'}),
           tests_require=test_requires,
           zip_safe=False
           )

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,12 @@ EXTENSIONS = [
         extra_compile_args=extra_compile_args,
         include_dirs=[np.get_include()],
     ),
+    Extension(
+        'geotiepoints._modis_utils',
+        sources=['geotiepoints/_modis_utils.pyx'],
+        extra_compile_args=extra_compile_args,
+        include_dirs=[np.get_include()],
+    ),
 ]
 
 cmdclass = versioneer.get_cmdclass()

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,12 @@ EXTENSIONS = [
         extra_compile_args=extra_compile_args,
         include_dirs=[np.get_include()],
     ),
+    Extension(
+        'geotiepoints._simple_modis_interpolator',
+        sources=['geotiepoints/_simple_modis_interpolator.pyx'],
+        extra_compile_args=extra_compile_args,
+        include_dirs=[np.get_include()],
+    ),
 ]
 
 cmdclass = versioneer.get_cmdclass()


### PR DESCRIPTION
This is a continuation of #36 but includes mostly changes to the simple modis interpolation since that PR. Doing this though required restructuring of the cython modules so I added a `_modis_utils.py`. The results of a simple test with some dask array based processing:

![image](https://user-images.githubusercontent.com/1828519/159135869-b898d18d-6392-4b91-8890-0986cf54008d.png)

This is about half the memory and half the processing time of a previous execution with the non-cython version. It also runs faster in the pure numpy case of a full granule, but *not* as fast as the #36 angle-based interpolation with pure numpy. So to put it another way, simple interpolation is faster and uses less memory than #36 *if* used with small and/or dask-based arrays, but it is slower than #36 for larger numpy arrays.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes) -->
 - [ ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
