### PR TITLE
Add right-most column "extrapolation" to simple modis interpolation

### DIFF
--- a/geotiepoints/simple_modis_interpolator.py
+++ b/geotiepoints/simple_modis_interpolator.py
@@ -171,6 +171,7 @@ def interpolate_geolocation_cartesian(lon_array, lat_array, res_factor=4):
         for nav_array, result_array in nav_arrays:
             # Use bilinear interpolation for all 250 meter pixels
             map_coordinates(nav_array[j0:j1, :], coordinates, output=result_array[k0:k1, :], order=1, mode='nearest')
+            _extrapolate_rightmost_columns(res_factor, result_array[k0:k1])
 
             if res_factor == 4:
                 # Use linear extrapolation for the first two 250 meter pixels along track
@@ -196,6 +197,14 @@ def interpolate_geolocation_cartesian(lon_array, lat_array, res_factor=4):
 
     new_lons, new_lats = xyz2lonlat(new_x, new_y, new_z, low_lat_z=True)
     return new_lons.astype(lon_array.dtype), new_lats.astype(lon_array.dtype)
+
+
+def _extrapolate_rightmost_columns(res_factor, result_array):
+    outer_columns_offset = 3 if res_factor == 4 else 1
+    # take the last two interpolated (not extrapolated) columns and find the difference
+    right_diff = result_array[:, -(outer_columns_offset + 1)] - result_array[:, -(outer_columns_offset + 2)]
+    for factor, column_idx in enumerate(range(-outer_columns_offset, 0)):
+        result_array[:, column_idx] += right_diff * (factor + 1)
 
 
 def _calc_slope_offset_250(result_array, y, start_idx, offset):


### PR DESCRIPTION
See #39. The simple interpolation has been shown to not properly deal with the extrapolated right-most columns of a swath. This PR adds a very basic form of extrapolation (if you can call it that) by repeating the amount of difference between the last two valid columns and using it on the last extrapolated columns.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes) -->
 - [ ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
