### PR TITLE
Fix deprecation for numpy array equality

### DIFF
--- a/geotiepoints/interpolator.py
+++ b/geotiepoints/interpolator.py
@@ -236,7 +236,7 @@ class Interpolator(object):
     def _interp(self):
         """Interpolate the cartesian coordinates.
         """
-        if np.all(self.hrow_indices == self.row_indices):
+        if np.array_equal(self.hrow_indices, self.row_indices):
             return self._interp1d()
 
         xpoints, ypoints = np.meshgrid(self.hrow_indices,


### PR DESCRIPTION
This PR fixes a pending deprecation becoming reality in numpy 1.24.0.

