### PR TITLE
Fix VII interpolator compatibility with future versions of xarray

### DIFF
--- a/geotiepoints/viiinterpolator.py
+++ b/geotiepoints/viiinterpolator.py
@@ -65,18 +65,18 @@ def tie_points_interpolation(data_on_tie_points, scan_alt_tie_points, tie_points
     n_pixel_alt = (n_tie_alt - 1) * tie_points_factor
 
     # Create the grids used for interpolation across the track
-    tie_grid_act = da.arange(0, n_pixel_act + 1, tie_points_factor)
-    pixel_grid_act = da.arange(0, n_pixel_act)
+    tie_grid_act = np.arange(0, n_pixel_act + 1, tie_points_factor)
+    pixel_grid_act = np.arange(0, n_pixel_act)
 
     # Create the grids used for the interpolation along the track (must not include the spurious points between scans)
-    tie_grid_alt = da.arange(0, n_pixel_alt + 1, tie_points_factor)
+    tie_grid_alt = np.arange(0, n_pixel_alt + 1, tie_points_factor)
     n_pixel_alt_per_scan = (scan_alt_tie_points - 1) * tie_points_factor
     pixel_grid_alt = []
 
     for j_scan in range(n_scans):
         start_index_scan = j_scan * scan_alt_tie_points * tie_points_factor
-        pixel_grid_alt.append(da.arange(start_index_scan, start_index_scan + n_pixel_alt_per_scan))
-    pixel_grid_alt = da.concatenate(pixel_grid_alt)
+        pixel_grid_alt.append(np.arange(start_index_scan, start_index_scan + n_pixel_alt_per_scan))
+    pixel_grid_alt = np.concatenate(pixel_grid_alt)
 
     # Loop on all arrays
     data_on_pixel_points = []


### PR DESCRIPTION
As first noticed in https://github.com/pytroll/satpy/pull/2416, there are failures for Satpy's VII reader tests when used with the unreleased version of xarray. Xarray is now more strict about using dask arrays for coordinates and indexing. The VII failure comes down to usage in this package and was a simple fix related to removing the use of dask. The arrays involved are relatively small and I think getting computed almost immediately by old xarray versions any way. This PR just converts everything to numpy.

CC @sjoro 

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes) -->
 - [ ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
