### PR TITLE
Upgrade to Cython 3+ in building

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -74,7 +74,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'python-geotiepoints'
-copyright = u'2012-%d, Pytroll Team' % datetime.utcnow().year  # noqa
+copyright = u'2012-%d, Python-geotiepoints Developers' % datetime.utcnow().year  # noqa
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/geotiepoints/__init__.py
+++ b/geotiepoints/__init__.py
@@ -1,29 +1,18 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
-# Copyright (c) 2010-2018.
-
-# Author(s):
-
-#   Adam Dybbroe <adam.dybbroe@smhise>
-#   Martin Raspaud <martin.raspaud@smhi.se>
-#   Panu Lahtinen <panu.lahtinen@fmi.fi>
-
+# Copyright (c) 2010-2018 Python-geotiepoints developers
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-"""Interpolation of geographical tiepoints.
-"""
+"""Interpolation of geographical tiepoints."""
 
 from multiprocessing import Pool
 

--- a/geotiepoints/_modis_interpolator.pyx
+++ b/geotiepoints/_modis_interpolator.pyx
@@ -1,3 +1,4 @@
+# cython: language_level=3, boundscheck=False, cdivision=True, wraparound=False, initializedcheck=False, nonecheck=False
 cimport cython
 from ._modis_utils cimport lonlat2xyz, xyz2lonlat, floating, deg2rad
 from .simple_modis_interpolator import scanline_mapblocks
@@ -9,6 +10,8 @@ import numpy as np
 DEF R = 6370.997
 # Aqua altitude in km
 DEF H = 709.0
+
+np.import_array()
 
 
 @scanline_mapblocks
@@ -35,12 +38,8 @@ def interpolate(
     return interp.interpolate(lon1, lat1, satz1)
 
 
-@cython.boundscheck(False)
-@cython.cdivision(True)
-@cython.wraparound(False)
-@cython.initializedcheck(False)
 cdef void _compute_expansion_alignment(floating[:, :] satz_a, floating [:, :] satz_b, int scan_width,
-                                       floating[:, ::1] c_expansion, floating[:, ::1] c_alignment) nogil:
+                                       floating[:, ::1] c_expansion, floating[:, ::1] c_alignment) noexcept nogil:
     """Fill in expansion and alignment.
     
     Input angles should be in degrees and will be converted to radians.
@@ -71,48 +70,24 @@ cdef void _compute_expansion_alignment(floating[:, :] satz_a, floating [:, :] sa
             c_alignment[i, j] = 4 * e * sin(zeta) / denominator
 
 
-cdef inline floating _compute_phi(floating zeta) nogil:
+cdef inline floating _compute_phi(floating zeta) noexcept nogil:
     return asin(R * sin(zeta) / (R + H))
 
 
-cdef inline floating _compute_theta(floating zeta, floating phi) nogil:
+cdef inline floating _compute_theta(floating zeta, floating phi) noexcept nogil:
     return zeta - phi
 
 
-cdef inline floating _compute_zeta(floating phi) nogil:
+cdef inline floating _compute_zeta(floating phi) noexcept nogil:
     return asin((R + H) * sin(phi) / R)
 
 
-@cython.boundscheck(False)
-@cython.cdivision(True)
-@cython.wraparound(False)
-@cython.initializedcheck(False)
 cdef inline floating[:, :] _get_upper_left_corner(floating[:, ::1] arr) nogil:
-    return arr[:-1, :-1]
+    return arr[:arr.shape[0] - 1, :arr.shape[1] - 1]
 
 
-@cython.boundscheck(False)
-@cython.cdivision(True)
-@cython.wraparound(False)
-@cython.initializedcheck(False)
 cdef inline floating[:, :] _get_upper_right_corner(floating[:, ::1] arr) nogil:
-    return arr[:-1, 1:]
-
-
-@cython.boundscheck(False)
-@cython.cdivision(True)
-@cython.wraparound(False)
-@cython.initializedcheck(False)
-cdef inline floating[:, :] _get_lower_right_corner(floating[:, ::1] arr) nogil:
-    return arr[1:, 1:]
-
-
-@cython.boundscheck(False)
-@cython.cdivision(True)
-@cython.wraparound(False)
-@cython.initializedcheck(False)
-cdef inline floating[:, :] _get_lower_left_corner(floating[:, ::1] arr) nogil:
-    return arr[1:, :-1]
+    return arr[:arr.shape[0] - 1, 1:]
 
 
 cdef class MODISInterpolator:
@@ -132,8 +107,6 @@ cdef class MODISInterpolator:
     cdef int _fine_resolution
     cdef Py_ssize_t _factor_5km
 
-    @cython.cdivision(True)
-    @cython.wraparound(False)
     def __cinit__(self, unsigned int coarse_resolution, unsigned int fine_resolution, unsigned int coarse_scan_width=0):
         if coarse_resolution == 1000:
             self._coarse_scan_length = 10
@@ -154,11 +127,7 @@ cdef class MODISInterpolator:
         # partial rows/columns to repeat: 5km->1km => 2, 5km->500m => 4, 5km->250m => 8
         self._factor_5km = self._fine_pixels_per_coarse_pixel // self._coarse_pixels_per_1km * 2
 
-    @cython.boundscheck(False)
-    @cython.cdivision(True)
-    @cython.wraparound(False)
-    @cython.initializedcheck(False)
-    cdef interpolate(
+    cdef tuple interpolate(
             self,
             np.ndarray[floating, ndim=2] lon1,
             np.ndarray[floating, ndim=2] lat1,
@@ -238,15 +207,11 @@ cdef class MODISInterpolator:
             x, y = self._get_coords_5km()
         return x, y
 
-    @cython.boundscheck(False)
-    @cython.cdivision(True)
-    @cython.wraparound(False)
-    @cython.initializedcheck(False)
     cdef void _get_coords_1km(
             self,
             floating[::1] x_view,
             floating[::1] y_view,
-    ) nogil:
+    ) noexcept nogil:
         cdef unsigned int scan_idx
         cdef int i
         cdef int fine_idx
@@ -263,9 +228,7 @@ cdef class MODISInterpolator:
         for i in range(self._fine_pixels_per_coarse_pixel):
             x_view[(self._fine_scan_width - self._fine_pixels_per_coarse_pixel) + i] = self._fine_pixels_per_coarse_pixel + i
 
-    @cython.boundscheck(False)
-    @cython.cdivision(True)
-    @cython.initializedcheck(False)
+    @cython.wraparound(True)
     cdef tuple _get_coords_5km(self):
         cdef np.ndarray[np.float32_t, ndim=1] y = np.arange(self._fine_pixels_per_coarse_pixel * self._coarse_scan_length, dtype=np.float32) - 2
         cdef np.ndarray[np.float32_t, ndim=1] x = (np.arange(self._fine_scan_width, dtype=np.float32) - 2) % self._fine_pixels_per_coarse_pixel
@@ -285,10 +248,6 @@ cdef class MODISInterpolator:
             x[-1] = 11
         return x, y
 
-    @cython.boundscheck(False)
-    @cython.cdivision(True)
-    @cython.wraparound(False)
-    @cython.initializedcheck(False)
     cdef void _interpolate_lons_lats(self,
                                      unsigned int scans,
                                      floating[:, ::1] coarse_lons,
@@ -306,7 +265,7 @@ cdef class MODISInterpolator:
                                      floating[:, :, ::1] fine_xyz,
                                      floating[:, ::1] fine_lons,
                                      floating[:, ::1] fine_lats,
-                                     ) nogil:
+                                     ) noexcept nogil:
         cdef floating[:, ::1] lons_scan, lats_scan, satz_scan
         cdef floating[:, ::1] new_lons_scan, new_lats_scan
         cdef Py_ssize_t scan_idx
@@ -333,10 +292,6 @@ cdef class MODISInterpolator:
 
             xyz2lonlat(fine_xyz, new_lons_scan, new_lats_scan)
 
-    @cython.boundscheck(False)
-    @cython.cdivision(True)
-    @cython.wraparound(False)
-    @cython.initializedcheck(False)
     cdef void _get_atrack_ascan(
             self,
             floating[:, ::1] satz,
@@ -348,7 +303,7 @@ cdef class MODISInterpolator:
             floating[:, ::1] c_ali_fine,
             floating[:, ::1] a_track,
             floating[:, ::1] a_scan
-    ) nogil:
+    ) noexcept nogil:
         cdef floating[:, :] satz_a_view = _get_upper_left_corner(satz)
         cdef floating[:, :] satz_b_view = _get_upper_right_corner(satz)
         cdef Py_ssize_t scan_idx
@@ -370,10 +325,6 @@ cdef class MODISInterpolator:
             c_exp_fine, c_ali_fine,
             a_track, a_scan)
 
-    @cython.boundscheck(False)
-    @cython.cdivision(True)
-    @cython.wraparound(False)
-    @cython.initializedcheck(False)
     cdef void _calculate_atrack_ascan(
             self,
             floating[::1] coords_x,
@@ -382,7 +333,7 @@ cdef class MODISInterpolator:
             floating[:, ::1] c_ali_full,
             floating[:, ::1] a_track,
             floating[:, ::1] a_scan,
-    ) nogil:
+    ) noexcept nogil:
         cdef Py_ssize_t i, j
         cdef floating s_s, s_t
         for j in range(coords_y.shape[0]):
@@ -392,10 +343,6 @@ cdef class MODISInterpolator:
                 a_track[j, i] = s_t
                 a_scan[j, i] = s_s + s_s * (1 - s_s) * c_exp_full[j, i] + s_t * (1 - s_t) * c_ali_full[j, i]
 
-    @cython.boundscheck(False)
-    @cython.cdivision(True)
-    @cython.wraparound(False)
-    @cython.initializedcheck(False)
     cdef void _compute_fine_xyz(
             self,
             floating[:, ::1] a_track_view,
@@ -406,7 +353,7 @@ cdef class MODISInterpolator:
             floating[:, ::1] data_tiepoint_c_view,
             floating[:, ::1] data_tiepoint_d_view,
             floating[:, :, ::1] xyz_comp_view,
-    ) nogil:
+    ) noexcept nogil:
         cdef Py_ssize_t k
         cdef floating[:, :] comp_a_view, comp_b_view, comp_c_view, comp_d_view
         for k in range(3):  # xyz
@@ -429,10 +376,6 @@ cdef class MODISInterpolator:
                 k,
             )
 
-    @cython.boundscheck(False)
-    @cython.cdivision(True)
-    @cython.wraparound(False)
-    @cython.initializedcheck(False)
     cdef void _compute_fine_xyz_component(
             self,
             floating[:, ::1] a_track_view,
@@ -443,7 +386,7 @@ cdef class MODISInterpolator:
             floating[:, ::1] data_d_2d_view,
             floating[:, :, ::1] xyz_comp_view,
             Py_ssize_t k,
-    ) nogil:
+    ) noexcept nogil:
         cdef Py_ssize_t i, j
         cdef floating scan1_tmp, scan2_tmp, atrack1, ascan1
         for i in range(a_scan_view.shape[0]):
@@ -458,25 +401,17 @@ cdef class MODISInterpolator:
             self,
             floating[:, :] input_arr,
             floating[:, ::1] output_arr,
-    ) nogil:
+    ) noexcept nogil:
         if self._coarse_scan_length == 10:
             self._expand_tiepoint_array_1km(input_arr, output_arr)
         else:
             self._expand_tiepoint_array_5km(input_arr, output_arr)
 
-    @cython.boundscheck(False)
-    @cython.cdivision(True)
-    @cython.wraparound(False)
-    @cython.initializedcheck(False)
-    cdef void _expand_tiepoint_array_1km(self, floating[:, :] input_arr, floating[:, ::1] expanded_arr) nogil:
+    cdef void _expand_tiepoint_array_1km(self, floating[:, :] input_arr, floating[:, ::1] expanded_arr) noexcept nogil:
         self._expand_tiepoint_array_1km_main(input_arr, expanded_arr)
         self._expand_tiepoint_array_1km_right_column(input_arr, expanded_arr)
 
-    @cython.boundscheck(False)
-    @cython.cdivision(True)
-    @cython.wraparound(False)
-    @cython.initializedcheck(False)
-    cdef void _expand_tiepoint_array_1km_main(self, floating[:, :] input_arr, floating[:, ::1] expanded_arr) nogil:
+    cdef void _expand_tiepoint_array_1km_main(self, floating[:, :] input_arr, floating[:, ::1] expanded_arr) noexcept nogil:
         cdef floating tiepoint_value
         cdef Py_ssize_t row_idx, col_idx, length_repeat_cycle, width_repeat_cycle, half_coarse_pixel_fine_offset, row_offset, col_offset
         cdef Py_ssize_t row_repeat_offset, col_repeat_offset
@@ -502,15 +437,11 @@ cdef class MODISInterpolator:
             tiepoint_value = input_arr[row_idx, col_idx]
             self._expand_tiepoint_array_1km_with_repeat(tiepoint_value, expanded_arr, row_offset, col_offset)
 
-    @cython.boundscheck(False)
-    @cython.cdivision(True)
-    @cython.wraparound(False)
-    @cython.initializedcheck(False)
     cdef void _expand_tiepoint_array_1km_right_column(
             self,
             floating[:, :] input_arr,
             floating[:, ::1] expanded_arr
-    ) nogil:
+    ) noexcept nogil:
         cdef floating tiepoint_value
         cdef Py_ssize_t row_idx, col_idx, length_repeat_cycle, width_repeat_cycle, half_coarse_pixel_fine_offset, row_offset, col_offset
         cdef Py_ssize_t row_repeat_offset, col_repeat_offset
@@ -525,15 +456,11 @@ cdef class MODISInterpolator:
         self._expand_tiepoint_array_1km_right_column_top_row(input_arr, expanded_arr)
         self._expand_tiepoint_array_1km_right_column_bottom_row(input_arr, expanded_arr)
 
-    @cython.boundscheck(False)
-    @cython.cdivision(True)
-    @cython.wraparound(False)
-    @cython.initializedcheck(False)
     cdef void _expand_tiepoint_array_1km_right_column_top_row(
             self,
             floating[:, :] input_arr,
             floating[:, ::1] expanded_arr
-    ) nogil:
+    ) noexcept nogil:
         cdef floating tiepoint_value
         cdef Py_ssize_t row_idx, col_idx, row_offset, col_offset
         row_idx = 0
@@ -543,15 +470,11 @@ cdef class MODISInterpolator:
         col_offset = col_idx * self._fine_pixels_per_coarse_pixel + self._fine_pixels_per_coarse_pixel
         self._expand_tiepoint_array_1km_with_repeat(tiepoint_value, expanded_arr, row_offset, col_offset)
 
-    @cython.boundscheck(False)
-    @cython.cdivision(True)
-    @cython.wraparound(False)
-    @cython.initializedcheck(False)
     cdef void _expand_tiepoint_array_1km_right_column_bottom_row(
             self,
             floating[:, :] input_arr,
             floating[:, ::1] expanded_arr
-    ) nogil:
+    ) noexcept nogil:
         cdef floating tiepoint_value
         cdef Py_ssize_t row_idx, col_idx, row_offset, col_offset
         row_idx = input_arr.shape[0] - 1
@@ -561,17 +484,13 @@ cdef class MODISInterpolator:
         col_offset = col_idx * self._fine_pixels_per_coarse_pixel + self._fine_pixels_per_coarse_pixel
         self._expand_tiepoint_array_1km_with_repeat(tiepoint_value, expanded_arr, row_offset, col_offset)
 
-    @cython.boundscheck(False)
-    @cython.cdivision(True)
-    @cython.wraparound(False)
-    @cython.initializedcheck(False)
     cdef void _expand_tiepoint_array_1km_with_repeat(
             self,
             floating tiepoint_value,
             floating[:, ::1] expanded_arr,
             Py_ssize_t row_offset,
             Py_ssize_t col_offset,
-    ) nogil:
+    ) noexcept nogil:
         cdef Py_ssize_t length_repeat_cycle, width_repeat_cycle
         cdef Py_ssize_t row_repeat_offset, col_repeat_offset
         for length_repeat_cycle in range(self._fine_pixels_per_coarse_pixel):
@@ -580,22 +499,14 @@ cdef class MODISInterpolator:
                 col_repeat_offset = col_offset + width_repeat_cycle
                 expanded_arr[row_repeat_offset, col_repeat_offset] = tiepoint_value
 
-    @cython.boundscheck(False)
-    @cython.cdivision(True)
-    @cython.wraparound(False)
-    @cython.initializedcheck(False)
-    cdef void _expand_tiepoint_array_5km(self, floating[:, :] input_arr, floating[:, ::1] expanded_arr) nogil:
+    cdef void _expand_tiepoint_array_5km(self, floating[:, :] input_arr, floating[:, ::1] expanded_arr) noexcept nogil:
         self._expand_tiepoint_array_5km_main(input_arr, expanded_arr)
         self._expand_tiepoint_array_5km_left(input_arr, expanded_arr)
         if self._coarse_scan_width == 270:
             self._expand_tiepoint_array_5km_270_extra_column(input_arr, expanded_arr)
         self._expand_tiepoint_array_5km_right(input_arr, expanded_arr)
 
-    @cython.boundscheck(False)
-    @cython.cdivision(True)
-    @cython.wraparound(False)
-    @cython.initializedcheck(False)
-    cdef void _expand_tiepoint_array_5km_main(self, floating[:, :] input_arr, floating[:, ::1] expanded_arr) nogil:
+    cdef void _expand_tiepoint_array_5km_main(self, floating[:, :] input_arr, floating[:, ::1] expanded_arr) noexcept nogil:
         cdef floating tiepoint_value
         cdef Py_ssize_t row_idx, col_idx, row_offset, col_offset
         for row_idx in range(input_arr.shape[0]):
@@ -610,15 +521,11 @@ cdef class MODISInterpolator:
                     col_offset,
                     self._fine_pixels_per_coarse_pixel)
 
-    @cython.boundscheck(False)
-    @cython.cdivision(True)
-    @cython.wraparound(False)
-    @cython.initializedcheck(False)
     cdef void _expand_tiepoint_array_5km_270_extra_column(
             self,
             floating[:, :] input_arr,
             floating[:, ::1] expanded_arr
-    ) nogil:
+    ) noexcept nogil:
         """Copy an extra coarse pixel column between the main copied area and the right-most columns."""
         cdef floating tiepoint_value
         cdef Py_ssize_t row_idx, col_idx, row_offset, col_offset
@@ -634,43 +541,31 @@ cdef class MODISInterpolator:
                 col_offset,
                 self._fine_pixels_per_coarse_pixel)
 
-    @cython.boundscheck(False)
-    @cython.cdivision(True)
-    @cython.wraparound(False)
-    @cython.initializedcheck(False)
     cdef void _expand_tiepoint_array_5km_left(
             self,
             floating[:, :] input_arr,
             floating[:, ::1] expanded_arr,
-    ) nogil:
+    ) noexcept nogil:
         self._expand_tiepoint_array_5km_edges(input_arr, expanded_arr, 0, 0)
 
-    @cython.boundscheck(False)
-    @cython.cdivision(True)
-    @cython.wraparound(False)
-    @cython.initializedcheck(False)
     cdef void _expand_tiepoint_array_5km_right(
             self,
             floating[:, :] input_arr,
             floating[:, ::1] expanded_arr,
-    ) nogil:
+    ) noexcept nogil:
         self._expand_tiepoint_array_5km_edges(
             input_arr,
             expanded_arr,
             input_arr.shape[1] - 1,
             expanded_arr.shape[1] - self._factor_5km)
 
-    @cython.boundscheck(False)
-    @cython.cdivision(True)
-    @cython.wraparound(False)
-    @cython.initializedcheck(False)
     cdef void _expand_tiepoint_array_5km_edges(
             self,
             floating[:, :] input_arr,
             floating[:, ::1] expanded_arr,
             Py_ssize_t course_col_idx,
             Py_ssize_t fine_col_idx,
-    ) nogil:
+    ) noexcept nogil:
         cdef floating tiepoint_value
         cdef Py_ssize_t row_idx, row_offset
         for row_idx in range(input_arr.shape[0]):
@@ -683,10 +578,6 @@ cdef class MODISInterpolator:
                 fine_col_idx,
                 self._factor_5km)
 
-    @cython.boundscheck(False)
-    @cython.cdivision(True)
-    @cython.wraparound(False)
-    @cython.initializedcheck(False)
     cdef void _expand_tiepoint_array_5km_with_repeat(
             self,
             floating tiepoint_value,
@@ -694,7 +585,7 @@ cdef class MODISInterpolator:
             Py_ssize_t row_offset,
             Py_ssize_t col_offset,
             Py_ssize_t col_width,
-    ) nogil:
+    ) noexcept nogil:
         cdef Py_ssize_t length_repeat_cycle, width_repeat_cycle
         for length_repeat_cycle in range(self._fine_pixels_per_coarse_pixel * 2):
             for width_repeat_cycle in range(col_width):

--- a/geotiepoints/_modis_interpolator.pyx
+++ b/geotiepoints/_modis_interpolator.pyx
@@ -82,11 +82,11 @@ cdef inline floating _compute_zeta(floating phi) noexcept nogil:
     return asin((R + H) * sin(phi) / R)
 
 
-cdef inline floating[:, :] _get_upper_left_corner(floating[:, ::1] arr) nogil:
+cdef inline floating[:, :] _get_upper_left_corner(floating[:, ::1] arr) noexcept nogil:
     return arr[:arr.shape[0] - 1, :arr.shape[1] - 1]
 
 
-cdef inline floating[:, :] _get_upper_right_corner(floating[:, ::1] arr) nogil:
+cdef inline floating[:, :] _get_upper_right_corner(floating[:, ::1] arr) noexcept nogil:
     return arr[:arr.shape[0] - 1, 1:]
 
 
@@ -357,10 +357,10 @@ cdef class MODISInterpolator:
         cdef Py_ssize_t k
         cdef floating[:, :] comp_a_view, comp_b_view, comp_c_view, comp_d_view
         for k in range(3):  # xyz
-            comp_a_view = xyz_view[:-1, :-1, k]  # upper left
-            comp_b_view = xyz_view[:-1, 1:, k]  # upper right
+            comp_a_view = xyz_view[:xyz_view.shape[0] - 1, :xyz_view.shape[1] - 1, k]  # upper left
+            comp_b_view = xyz_view[:xyz_view.shape[0] - 1, 1:, k]  # upper right
             comp_c_view = xyz_view[1:, 1:, k]  # lower right
-            comp_d_view = xyz_view[1:, :-1, k]  # lower left
+            comp_d_view = xyz_view[1:, :xyz_view.shape[1] - 1, k]  # lower left
             self._expand_tiepoint_array(comp_a_view, data_tiepoint_a_view)
             self._expand_tiepoint_array(comp_b_view, data_tiepoint_b_view)
             self._expand_tiepoint_array(comp_c_view, data_tiepoint_c_view)

--- a/geotiepoints/_modis_utils.pxd
+++ b/geotiepoints/_modis_utils.pxd
@@ -1,3 +1,4 @@
+# cython: language_level=3, boundscheck=False, cdivision=True, wraparound=False, initializedcheck=False, nonecheck=False
 cimport numpy as np
 
 ctypedef fused floating:
@@ -8,7 +9,7 @@ cdef void lonlat2xyz(
         floating[:, ::1] lons,
         floating[:, ::1] lats,
         floating[:, :, ::1] xyz,
-) nogil
+) noexcept nogil
 
 cdef void xyz2lonlat(
         floating[:, :, ::1] xyz,
@@ -16,7 +17,7 @@ cdef void xyz2lonlat(
         floating[:, ::1] lats,
         bint low_lat_z=*,
         floating thr=*,
-) nogil
+) noexcept nogil
 
-cdef floating rad2deg(floating x) nogil
-cdef floating deg2rad(floating x) nogil
+cdef floating rad2deg(floating x) noexcept nogil
+cdef floating deg2rad(floating x) noexcept nogil

--- a/geotiepoints/_simple_modis_interpolator.pyx
+++ b/geotiepoints/_simple_modis_interpolator.pyx
@@ -1,3 +1,4 @@
+# cython: language_level=3, boundscheck=False, cdivision=True, wraparound=False, initializedcheck=False, nonecheck=False
 cimport cython
 
 from ._modis_utils cimport floating
@@ -7,6 +8,7 @@ cimport numpy as np
 import numpy as np
 from scipy.ndimage import map_coordinates
 
+np.import_array()
 
 def interpolate_geolocation_cartesian(
         np.ndarray[floating, ndim=2] lon_array,
@@ -69,7 +71,7 @@ def interpolate_geolocation_cartesian(
 cdef void _compute_yx_coordinate_arrays(
         unsigned int res_factor,
         floating[:, :, ::1] coordinates,
-) nogil:
+) noexcept nogil:
     cdef Py_ssize_t i, j
     for j in range(coordinates.shape[1]):
         for i in range(coordinates.shape[2]):
@@ -85,7 +87,7 @@ cdef void _compute_interpolated_xyz_scan(
         floating[:, :, ::1] coordinates_view,
         floating[:, :, ::1] xyz_input_view,
         floating[:, :, ::1] xyz_result_view,
-) nogil:
+) noexcept nogil:
     cdef Py_ssize_t comp_index
     cdef floating[:, :] input_view, result_view
     with gil:
@@ -137,7 +139,7 @@ cdef void _call_map_coordinates(
 cdef void _extrapolate_xyz_rightmost_columns(
         floating[:, :] result_view,
         int num_columns,
-) nogil:
+) noexcept nogil:
     cdef Py_ssize_t row_idx, col_offset
     cdef floating last_interp_col_diff
     for row_idx in range(result_view.shape[0]):
@@ -155,7 +157,7 @@ cdef void _extrapolate_xyz_rightmost_columns(
 cdef void _interpolate_xyz_250(
         floating[:, :] result_view,
         floating[:, :, ::1] coordinates_view,
-) nogil:
+) noexcept nogil:
     cdef Py_ssize_t col_idx
     cdef floating m, b
     cdef floating[:] result_col_view
@@ -194,7 +196,7 @@ cdef void _interpolate_xyz_250(
 cdef void _interpolate_xyz_500(
         floating[:, :] result_view,
         floating[:, :, ::1] coordinates_view,
-) nogil:
+) noexcept nogil:
     cdef Py_ssize_t col_idx
     cdef floating m, b
     for col_idx in range(result_view.shape[1]):
@@ -231,7 +233,7 @@ cdef inline floating _calc_slope_250(
         floating[:] result_view,
         floating[:, ::1] y,
         Py_ssize_t offset,
-) nogil:
+) noexcept nogil:
     return (result_view[offset + 3] - result_view[offset]) / \
            (y[offset + 3, 0] - y[offset, 0])
 
@@ -257,7 +259,7 @@ cdef inline floating _calc_slope_500(
         floating[:] result_view,
         floating[:, ::1] y,
         Py_ssize_t offset,
-) nogil:
+) noexcept nogil:
     return (result_view[offset + 1] - result_view[offset]) / \
            (y[offset + 1, 0] - y[offset, 0])
 
@@ -271,5 +273,5 @@ cdef inline floating _calc_offset_500(
         floating[:, ::1] y,
         floating m,
         Py_ssize_t offset,
-) nogil:
+) noexcept nogil:
     return result_view[offset + 1] - m * y[offset + 1, 0]

--- a/geotiepoints/interpolator.py
+++ b/geotiepoints/interpolator.py
@@ -1,25 +1,17 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
-# Copyright (c) 2013-2018 PyTroll community
-
-# Author(s):
-
-#   Martin Raspaud <martin.raspaud@smhi.se>
-
+# Copyright (c) 2013-2018 Python-geotiepoints developers
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 """Generic interpolation routines."""
 
 import numpy as np

--- a/geotiepoints/modisinterpolator.py
+++ b/geotiepoints/modisinterpolator.py
@@ -1,22 +1,15 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
-# Copyright (c) 2018 PyTroll community
-
-# Author(s):
-
-#   Martin Raspaud <martin.raspaud@smhi.se>
-
+# Copyright (c) 2018-2023 Python-geotiepoints developers
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Interpolation of MODIS data using satellite zenith angle.

--- a/geotiepoints/multilinear.py
+++ b/geotiepoints/multilinear.py
@@ -17,8 +17,7 @@ def mlinspace(smin, smax, orders):
 
 
 class MultilinearInterpolator:
-
-    '''Multilinear interpolation
+    """Multilinear interpolation.
 
     Methods
     -------
@@ -55,14 +54,14 @@ class MultilinearInterpolator:
 
     interpolated_values = interp(random_points)
     exact_values = f(random_points)
-    '''
+    """
 
     __grid__ = None
 
     def __init__(self, smin, smax, orders, values=None, dtype=np.float64):
-        self.smin = np.array(smin, dtype=dtype)
-        self.smax = np.array(smax, dtype=dtype)
-        self.orders = np.array(orders, dtype=np.int_)
+        self.smin = np.array(smin, dtype=dtype, copy=False)
+        self.smax = np.array(smax, dtype=dtype, copy=False)
+        self.orders = np.array(orders, dtype=np.int_, copy=False)
         self.d = len(orders)
         self.dtype = dtype
         if values is not None:

--- a/geotiepoints/multilinear_cython.pyx
+++ b/geotiepoints/multilinear_cython.pyx
@@ -1,18 +1,14 @@
+# cython: language_level=3, boundscheck=False, cdivision=True, wraparound=False, initializedcheck=False, nonecheck=False
 
-# generation options
-
-# some helper functions
-
-from libc.math cimport fmin, fmax, floor
 cimport cython
 from cython.parallel import prange,parallel
+from cython cimport floating
 
 cimport numpy as np
 import numpy as np
 
-ctypedef fused floating:
-    float
-    double
+np.import_array()
+
 
 def multilinear_interpolation(floating[:] smin, floating[:] smax, long[:] orders, floating[:,::1] values, floating[:,::1] s):
 
@@ -48,18 +44,12 @@ def multilinear_interpolation(floating[:] smin, floating[:] smax, long[:] orders
 
     return np.array(result,dtype=dtype)
 
-@cython.boundscheck(False)
-@cython.cdivision(True)
-@cython.wraparound(False)
+
 cdef multilinear_interpolation_1d(floating[:] smin, floating[:] smax,
                                   long[:] orders, floating[:] V,
                                   int n_s, floating[:,::1] s, floating[:] output):
 
-    cdef int d = 1
-
     cdef int i
-
-
     cdef floating lam_0, s_0, sn_0, snt_0
     cdef int order_0 = orders[0]
     cdef int q_0
@@ -88,18 +78,11 @@ cdef multilinear_interpolation_1d(floating[:] smin, floating[:] smax,
             output[i] = (1-lam_0)*(v_0) + (lam_0)*(v_1)
 
 
-@cython.boundscheck(False)
-@cython.cdivision(True)
-@cython.wraparound(False)
 cdef multilinear_interpolation_2d(floating[:] smin, floating[:] smax,
                                   long[:] orders, floating[:] V,
                                   int n_s, floating[:,::1] s, floating[:] output):
 
-    cdef int d = 2
-
     cdef int i
-
-
     cdef floating lam_0, s_0, sn_0, snt_0
     cdef floating lam_1, s_1, sn_1, snt_1
     cdef int order_0 = orders[0]
@@ -140,18 +123,10 @@ cdef multilinear_interpolation_2d(floating[:] smin, floating[:] smax,
             output[i] = (1-lam_0)*((1-lam_1)*(v_00) + (lam_1)*(v_01)) + (lam_0)*((1-lam_1)*(v_10) + (lam_1)*(v_11))
 
 
-@cython.boundscheck(False)
-@cython.cdivision(True)
-@cython.wraparound(False)
 cdef multilinear_interpolation_3d(floating[:] smin, floating[:] smax,
                                   long[:] orders, floating[:] V,
                                   int n_s, floating[:,::1] s, floating[:] output):
-
-    cdef int d = 3
-
     cdef int i
-
-
     cdef floating lam_0, s_0, sn_0, snt_0
     cdef floating lam_1, s_1, sn_1, snt_1
     cdef floating lam_2, s_2, sn_2, snt_2
@@ -208,18 +183,11 @@ cdef multilinear_interpolation_3d(floating[:] smin, floating[:] smax,
             output[i] = (1-lam_0)*((1-lam_1)*((1-lam_2)*(v_000) + (lam_2)*(v_001)) + (lam_1)*((1-lam_2)*(v_010) + (lam_2)*(v_011))) + (lam_0)*((1-lam_1)*((1-lam_2)*(v_100) + (lam_2)*(v_101)) + (lam_1)*((1-lam_2)*(v_110) + (lam_2)*(v_111)))
 
 
-@cython.boundscheck(False)
-@cython.cdivision(True)
-@cython.wraparound(False)
 cdef multilinear_interpolation_4d(floating[:] smin, floating[:] smax,
                                   long[:] orders, floating[:] V,
                                   int n_s, floating[:,::1] s, floating[:] output):
 
-    cdef int d = 4
-
     cdef int i
-
-
     cdef floating lam_0, s_0, sn_0, snt_0
     cdef floating lam_1, s_1, sn_1, snt_1
     cdef floating lam_2, s_2, sn_2, snt_2
@@ -300,18 +268,10 @@ cdef multilinear_interpolation_4d(floating[:] smin, floating[:] smax,
             output[i] = (1-lam_0)*((1-lam_1)*((1-lam_2)*((1-lam_3)*(v_0000) + (lam_3)*(v_0001)) + (lam_2)*((1-lam_3)*(v_0010) + (lam_3)*(v_0011))) + (lam_1)*((1-lam_2)*((1-lam_3)*(v_0100) + (lam_3)*(v_0101)) + (lam_2)*((1-lam_3)*(v_0110) + (lam_3)*(v_0111)))) + (lam_0)*((1-lam_1)*((1-lam_2)*((1-lam_3)*(v_1000) + (lam_3)*(v_1001)) + (lam_2)*((1-lam_3)*(v_1010) + (lam_3)*(v_1011))) + (lam_1)*((1-lam_2)*((1-lam_3)*(v_1100) + (lam_3)*(v_1101)) + (lam_2)*((1-lam_3)*(v_1110) + (lam_3)*(v_1111))))
 
 
-@cython.boundscheck(False)
-@cython.cdivision(True)
-@cython.wraparound(False)
 cdef multilinear_interpolation_5d(floating[:] smin, floating[:] smax,
                                   long[:] orders, floating[:] V,
                                   int n_s, floating[:,::1] s, floating[:] output):
-
-    cdef int d = 5
-
     cdef int i
-
-
     cdef floating lam_0, s_0, sn_0, snt_0
     cdef floating lam_1, s_1, sn_1, snt_1
     cdef floating lam_2, s_2, sn_2, snt_2

--- a/geotiepoints/multilinear_cython.pyx
+++ b/geotiepoints/multilinear_cython.pyx
@@ -21,7 +21,7 @@ def multilinear_interpolation(floating[:] smin, floating[:] smax, long[:] orders
     else:
         dtype = np.double
 
-    cdef np.ndarray[floating, ndim=2] result_arr = np.zeros((n_v, n_s), dtype=dtype)
+    cdef np.ndarray[floating, ndim=2] result_arr = np.empty((n_v, n_s), dtype=dtype)
     cdef floating[:, ::1] result = result_arr
     cdef floating[:] vals
     cdef floating[:] res

--- a/geotiepoints/tests/__init__.py
+++ b/geotiepoints/tests/__init__.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-# Copyright (c) 2017 Adam.Dybbroe
+# Copyright (c) 2017 Python-geotiepoints developers
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "oldest-supported-numpy", "Cython", "versioneer"]
+requires = ["setuptools", "wheel", "oldest-supported-numpy", "Cython>=3", "versioneer"]
 build-backend = "setuptools.build_meta"
 
 [tool.coverage.run]

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@
 
 import sys
 
-from setuptools import setup
+from setuptools import setup, find_packages
 import versioneer
 import numpy as np
 from Cython.Build import build_ext
@@ -77,7 +77,7 @@ except ValueError:
 cython_directives = {
     "language_level": "3",
 }
-define_macros = []
+define_macros = [("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")]
 if cython_coverage:
     print("Enabling directives/macros for Cython coverage support")
     cython_directives.update({
@@ -88,9 +88,9 @@ if cython_coverage:
         ("CYTHON_TRACE", "1"),
         ("CYTHON_TRACE_NOGIL", "1"),
     ])
-    for ext in EXTENSIONS:
-        ext.define_macros = define_macros
-        ext.cython_directives.update(cython_directives)
+for ext in EXTENSIONS:
+    ext.define_macros = define_macros
+    ext.cython_directives.update(cython_directives)
 
 cmdclass = versioneer.get_cmdclass(cmdclass={"build_ext": build_ext})
 
@@ -113,10 +113,8 @@ if __name__ == "__main__":
                        "Programming Language :: Cython",
                        "Topic :: Scientific/Engineering"],
           url="https://github.com/pytroll/python-geotiepoints",
-          packages=['geotiepoints'],
-          # packages=find_packages(),
-          setup_requires=['numpy', 'cython'],
-          python_requires='>=3.7',
+          packages=find_packages(),
+          python_requires='>=3.8',
           cmdclass=cmdclass,
           install_requires=requirements,
           ext_modules=EXTENSIONS,

--- a/setup.py
+++ b/setup.py
@@ -1,26 +1,17 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
-# Copyright (c) 2012-2018 PyTroll community
-
-# Author(s):
-
-#   Adam Dybbroe <adam.dybbroe@smhi.se>
-#   Martin Raspaud <martin.raspaud@smhi.se>
-
+# Copyright (c) 2012-2023 Python-geotiepoints developers
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 """Setting up the geo_interpolator project."""
 
 import sys


### PR DESCRIPTION
This PR upgrades the build dependencies to use Cython 3+. It also adds extra annotations required by Cython 3 to avoid extra Python-related checks and stay in C-land longer and with no GIL. As far as I can tell nothing of the generated code should be different to what it was.

Note I had concerns because the modis interpolation has some low-level functions with GIL-related when memory views are returned. I made a stackoverflow question about it and a Cython maintainer responded:

https://stackoverflow.com/questions/76972950/cython-returned-memoryview-is-always-considered-uninitialized

Basically, even though it is checking the memory view for validity/initialization, it is not actually acquiring the GIL except in the failure case which should never happen for us. We could restructure the code to not create a copy of the memory views used but instead adjust the indexing appropriately. The code would be harder to read but would not have the extra memoryview checks. I doubt it would have any performance difference.

I have not run a comparison of the performance, but given the logical changes appearing in the Cython I'm not too worried. I'll have to track down my old benchmarking from the last time the Cython was touched.

 - [x] Closes #56  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes) -->
 - [ ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
