### PR TITLE
Fix python versions in deploy ci

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, macos-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         include:
           # Using pythons inside a docker image to provide all the Linux
           # python-versions permutations.


### PR DESCRIPTION
This PR fixes the python versions for the deploy script of the ci
