### PR TITLE
Build wheels with numpy 2.0rc1 and fix scipy 1.13.0 compatibility

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
         if: matrix.experimental == true
         shell: bash -l {0}
         run: |
-          python -m pip install versioneer; \
+          python -m pip install versioneer pkgconfig; \
           conda uninstall --force-remove -y scipy h5py; \
           python -m pip install \
           -f https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/ \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,7 @@ jobs:
         if: matrix.experimental == true
         shell: bash -l {0}
         run: |
+          python -m pip install versioneer; \
           python -m pip install \
           -f https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/ \
           --no-deps --pre --upgrade \
@@ -50,7 +51,7 @@ jobs:
           pandas \
           scipy; \
           python -m pip install \
-          --no-deps --upgrade \
+          --no-deps --upgrade --pre --no-build-isolation \
           git+https://github.com/dask/dask \
           git+https://github.com/dask/distributed \
           git+https://github.com/zarr-developers/zarr \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,8 +42,8 @@ jobs:
         if: matrix.experimental == true
         shell: bash -l {0}
         run: |
-          python -m pip install versioneer pkgconfig; \
-          conda uninstall --force-remove -y scipy h5py pykdtree; \
+          python -m pip install versioneer pkgconfig setuptools-scm; \
+          conda uninstall --force-remove -y scipy h5py pyresample pykdtree; \
           python -m pip install \
           -f https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/ \
           --trusted-host pypi.anaconda.org \
@@ -58,6 +58,7 @@ jobs:
           git+https://github.com/dask/distributed \
           git+https://github.com/h5py/h5py \
           git+https://github.com/storpipfugl/pykdtree \
+          git+https://github.com/pytroll/pyresample \
           git+https://github.com/zarr-developers/zarr \
           git+https://github.com/pydata/bottleneck \
           git+https://github.com/pydata/xarray;

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,7 @@ jobs:
           python -m pip install versioneer; \
           python -m pip install \
           -f https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/ \
+          --trusted-host pypi.anaconda.org \
           --no-deps --pre --upgrade \
           matplotlib \
           numpy \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
         shell: bash -l {0}
         run: |
           python -m pip install versioneer; \
-          conda uninstall --force-remove -y scipy; \
+          conda uninstall --force-remove -y scipy h5py; \
           python -m pip install \
           -f https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/ \
           --trusted-host pypi.anaconda.org \
@@ -56,6 +56,7 @@ jobs:
           --no-deps --upgrade --pre --no-build-isolation \
           git+https://github.com/dask/dask \
           git+https://github.com/dask/distributed \
+          git+https://github.com/h5py/h5py \
           git+https://github.com/zarr-developers/zarr \
           git+https://github.com/pydata/bottleneck \
           git+https://github.com/pydata/xarray;

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
         shell: bash -l {0}
         run: |
           python -m pip install versioneer pkgconfig; \
-          conda uninstall --force-remove -y scipy h5py; \
+          conda uninstall --force-remove -y scipy h5py pykdtree; \
           python -m pip install \
           -f https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/ \
           --trusted-host pypi.anaconda.org \
@@ -57,6 +57,7 @@ jobs:
           git+https://github.com/dask/dask \
           git+https://github.com/dask/distributed \
           git+https://github.com/h5py/h5py \
+          git+https://github.com/storpipfugl/pykdtree \
           git+https://github.com/zarr-developers/zarr \
           git+https://github.com/pydata/bottleneck \
           git+https://github.com/pydata/xarray;

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
         shell: bash -l {0}
         run: |
           python -m pip install versioneer pkgconfig setuptools-scm; \
-          conda uninstall --force-remove -y scipy h5py pyresample pykdtree; \
+          conda uninstall --force-remove -y scipy h5py pyresample pykdtree pandas xarray; \
           python -m pip install \
           -f https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/ \
           --trusted-host pypi.anaconda.org \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,6 +43,7 @@ jobs:
         shell: bash -l {0}
         run: |
           python -m pip install versioneer; \
+          conda uninstall --force-remove -y scipy; \
           python -m pip install \
           -f https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/ \
           --trusted-host pypi.anaconda.org \

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -64,9 +64,6 @@ jobs:
           CIBW_SKIP: "cp36-* cp37-* cp38-* pp* *-manylinux_i686 *-musllinux_i686 *-musllinux_aarch64 *-win32"
           CIBW_ARCHS: "${{ matrix.cibw_archs }}"
           CIBW_TEST_SKIP: "*_arm64 *_universal2:arm64"
-          # below only for building against unstable numpy
-          CIBW_BUILD_FRONTEND: "pip; args: --no-build-isolation"
-          CIBW_BEFORE_BUILD: "pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy cython setuptools versioneer"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/geotiepoints/multilinear.py
+++ b/geotiepoints/multilinear.py
@@ -13,7 +13,7 @@ def mlinspace(smin, smax, orders):
     else:
         meshes = np.meshgrid(
             *[np.linspace(smin[i], smax[i], orders[i]) for i in range(len(orders))], indexing='ij')
-        return np.row_stack([l.flatten() for l in meshes])
+        return np.vstack([l.flatten() for l in meshes])
 
 
 class MultilinearInterpolator:
@@ -44,8 +44,8 @@ class MultilinearInterpolator:
     smax = [1,1]
     orders = [5,5]
 
-    f = lambda x: np.row_stack([np.sqrt( x[0,:]**2 + x[1,:]**2 ), 
-                                np.power( x[0,:]**3 + x[1,:]**3, 1.0/3.0 )])
+    f = lambda x: np.vstack([np.sqrt( x[0,:]**2 + x[1,:]**2 ),
+                             np.power( x[0,:]**3 + x[1,:]**3, 1.0/3.0 )])
 
     interp = MultilinearInterpolator(smin,smax,orders)
     interp.set_values( f(interp.grid) )

--- a/geotiepoints/multilinear.py
+++ b/geotiepoints/multilinear.py
@@ -59,9 +59,9 @@ class MultilinearInterpolator:
     __grid__ = None
 
     def __init__(self, smin, smax, orders, values=None, dtype=np.float64):
-        self.smin = np.array(smin, dtype=dtype, copy=False)
-        self.smax = np.array(smax, dtype=dtype, copy=False)
-        self.orders = np.array(orders, dtype=np.int_, copy=False)
+        self.smin = np.asarray(smin, dtype=dtype)
+        self.smax = np.asarray(smax, dtype=dtype)
+        self.orders = np.asarray(orders, dtype=np.int_)
         self.d = len(orders)
         self.dtype = dtype
         if values is not None:

--- a/geotiepoints/tests/test_interpolator.py
+++ b/geotiepoints/tests/test_interpolator.py
@@ -349,12 +349,12 @@ class TestSingleGridInterpolator:
         fine_x = np.arange(16)
         fine_y = np.arange(32)
 
-        res = grid_interpolator.interpolate((fine_y, fine_x), method="cubic")
+        res = grid_interpolator.interpolate((fine_y, fine_x), method="cubic_legacy")
         np.testing.assert_allclose(res, self.expected, atol=2e-9)
 
     def test_interpolate_slices(self, grid_interpolator):
         """Test that interpolation from slices is working."""
-        res = grid_interpolator.interpolate_slices((slice(0, 32), slice(0, 16)), method="cubic")
+        res = grid_interpolator.interpolate_slices((slice(0, 32), slice(0, 16)), method="cubic_legacy")
         np.testing.assert_allclose(res, self.expected, atol=2e-9)
 
     @pytest.mark.parametrize("chunks, expected_chunks", [(10, (10, 10)),
@@ -369,7 +369,7 @@ class TestSingleGridInterpolator:
         with mock.patch.object(grid_interpolator,
                                "interpolate_numpy",
                                wraps=grid_interpolator.interpolate_numpy) as interpolate:
-            res = grid_interpolator.interpolate((fine_y, fine_x), method="cubic", chunks=chunks)
+            res = grid_interpolator.interpolate((fine_y, fine_x), method="cubic_legacy", chunks=chunks)
             assert not interpolate.called
 
             assert isinstance(res, da.Array)
@@ -395,5 +395,5 @@ class TestSingleGridInterpolator:
         fine_x = np.arange(16)
         fine_y = np.arange(32)
 
-        res = grid_interpolator.interpolate((fine_y, fine_x), method="cubic")
+        res = grid_interpolator.interpolate((fine_y, fine_x), method="cubic_legacy")
         assert res.dtype == data.dtype

--- a/geotiepoints/tests/test_multilinear.py
+++ b/geotiepoints/tests/test_multilinear.py
@@ -70,7 +70,7 @@ class TestMultilinearInterpolator(unittest.TestCase):
         smax = [1, 1]
         orders = [5, 5]
 
-        f = lambda x: np.row_stack([
+        f = lambda x: np.vstack([
             np.sqrt(x[0, :]**2 + x[1, :]**2),
             np.power(x[0, :]**3 + x[1, :]**3, 1.0 / 3.0)
         ])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "oldest-supported-numpy", "Cython>=3", "versioneer"]
+requires = ["setuptools", "wheel", "numpy>=2.0.0rc1,<3", "Cython>=3", "versioneer"]
 build-backend = "setuptools.build_meta"
 
 [tool.coverage.run]


### PR DESCRIPTION
The numpy 2 api is stable now.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes) -->
 - [ ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
