### PR TITLE
Fix numpy 2 dtype issues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,6 @@ jobs:
           git+https://github.com/h5py/h5py \
           git+https://github.com/storpipfugl/pykdtree \
           git+https://github.com/pytroll/pyresample \
-          git+https://github.com/zarr-developers/zarr \
           git+https://github.com/pydata/bottleneck \
           git+https://github.com/pydata/xarray;
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -37,7 +37,7 @@ jobs:
           - os: windows-2019
             cibw_archs: "AMD64 ARM64"
             artifact_name: "win"
-          - os: macos-11
+          - os: macos-latest
             cibw_archs: "x86_64 arm64"
             artifact_name: "mac"
           - os: "ubuntu-20.04"

--- a/geotiepoints/multilinear.py
+++ b/geotiepoints/multilinear.py
@@ -61,7 +61,7 @@ class MultilinearInterpolator:
     def __init__(self, smin, smax, orders, values=None, dtype=np.float64):
         self.smin = np.asarray(smin, dtype=dtype)
         self.smax = np.asarray(smax, dtype=dtype)
-        self.orders = np.asarray(orders, dtype=np.int_)
+        self.orders = np.asarray(orders, dtype=np.int64)
         self.d = len(orders)
         self.dtype = dtype
         if values is not None:

--- a/geotiepoints/multilinear.py
+++ b/geotiepoints/multilinear.py
@@ -61,7 +61,7 @@ class MultilinearInterpolator:
     def __init__(self, smin, smax, orders, values=None, dtype=np.float64):
         self.smin = np.asarray(smin, dtype=dtype)
         self.smax = np.asarray(smax, dtype=dtype)
-        self.orders = np.asarray(orders, dtype=np.int64)
+        self.orders = np.asarray(orders, dtype="long")
         self.d = len(orders)
         self.dtype = dtype
         if values is not None:

--- a/geotiepoints/multilinear_cython.pyx
+++ b/geotiepoints/multilinear_cython.pyx
@@ -10,7 +10,7 @@ import numpy as np
 np.import_array()
 
 
-def multilinear_interpolation(floating[:] smin, floating[:] smax, long[:] orders, floating[:,::1] values, floating[:,::1] s):
+def multilinear_interpolation(floating[:] smin, floating[:] smax, int[:] orders, floating[:,::1] values, floating[:,::1] s):
 
     cdef Py_ssize_t d = s.shape[0]
     cdef Py_ssize_t n_s = s.shape[1]
@@ -46,7 +46,7 @@ def multilinear_interpolation(floating[:] smin, floating[:] smax, long[:] orders
 
 
 cdef void multilinear_interpolation_1d(floating[:] smin, floating[:] smax,
-                                       long[:] orders, floating[:] V,
+                                       int[:] orders, floating[:] V,
                                        int n_s, floating[:,::1] s, floating[:] output) noexcept nogil:
 
     cdef int i
@@ -79,7 +79,7 @@ cdef void multilinear_interpolation_1d(floating[:] smin, floating[:] smax,
 
 
 cdef void multilinear_interpolation_2d(floating[:] smin, floating[:] smax,
-                                       long[:] orders, floating[:] V,
+                                       int[:] orders, floating[:] V,
                                        int n_s, floating[:,::1] s, floating[:] output) noexcept nogil:
 
     cdef int i
@@ -124,7 +124,7 @@ cdef void multilinear_interpolation_2d(floating[:] smin, floating[:] smax,
 
 
 cdef void multilinear_interpolation_3d(floating[:] smin, floating[:] smax,
-                                       long[:] orders, floating[:] V,
+                                       int[:] orders, floating[:] V,
                                        int n_s, floating[:,::1] s, floating[:] output) noexcept nogil:
     cdef int i
     cdef floating lam_0, s_0, sn_0, snt_0
@@ -184,7 +184,7 @@ cdef void multilinear_interpolation_3d(floating[:] smin, floating[:] smax,
 
 
 cdef void multilinear_interpolation_4d(floating[:] smin, floating[:] smax,
-                                       long[:] orders, floating[:] V,
+                                       int[:] orders, floating[:] V,
                                        int n_s, floating[:,::1] s, floating[:] output) noexcept nogil:
 
     cdef int i
@@ -269,7 +269,7 @@ cdef void multilinear_interpolation_4d(floating[:] smin, floating[:] smax,
 
 
 cdef void multilinear_interpolation_5d(floating[:] smin, floating[:] smax,
-                                       long[:] orders, floating[:] V,
+                                       int[:] orders, floating[:] V,
                                        int n_s, floating[:,::1] s, floating[:] output) noexcept nogil:
     cdef int i
     cdef floating lam_0, s_0, sn_0, snt_0

--- a/geotiepoints/multilinear_cython.pyx
+++ b/geotiepoints/multilinear_cython.pyx
@@ -10,7 +10,7 @@ import numpy as np
 np.import_array()
 
 
-def multilinear_interpolation(floating[:] smin, floating[:] smax, int[:] orders, floating[:,::1] values, floating[:,::1] s):
+def multilinear_interpolation(floating[:] smin, floating[:] smax, np.int64_t[:] orders, floating[:,::1] values, floating[:,::1] s):
 
     cdef Py_ssize_t d = s.shape[0]
     cdef Py_ssize_t n_s = s.shape[1]
@@ -46,7 +46,7 @@ def multilinear_interpolation(floating[:] smin, floating[:] smax, int[:] orders,
 
 
 cdef void multilinear_interpolation_1d(floating[:] smin, floating[:] smax,
-                                       int[:] orders, floating[:] V,
+                                       np.int64_t[:] orders, floating[:] V,
                                        int n_s, floating[:,::1] s, floating[:] output) noexcept nogil:
 
     cdef int i
@@ -79,7 +79,7 @@ cdef void multilinear_interpolation_1d(floating[:] smin, floating[:] smax,
 
 
 cdef void multilinear_interpolation_2d(floating[:] smin, floating[:] smax,
-                                       int[:] orders, floating[:] V,
+                                       np.int64_t[:] orders, floating[:] V,
                                        int n_s, floating[:,::1] s, floating[:] output) noexcept nogil:
 
     cdef int i
@@ -124,7 +124,7 @@ cdef void multilinear_interpolation_2d(floating[:] smin, floating[:] smax,
 
 
 cdef void multilinear_interpolation_3d(floating[:] smin, floating[:] smax,
-                                       int[:] orders, floating[:] V,
+                                       np.int64_t[:] orders, floating[:] V,
                                        int n_s, floating[:,::1] s, floating[:] output) noexcept nogil:
     cdef int i
     cdef floating lam_0, s_0, sn_0, snt_0
@@ -184,7 +184,7 @@ cdef void multilinear_interpolation_3d(floating[:] smin, floating[:] smax,
 
 
 cdef void multilinear_interpolation_4d(floating[:] smin, floating[:] smax,
-                                       int[:] orders, floating[:] V,
+                                       np.int64_t[:] orders, floating[:] V,
                                        int n_s, floating[:,::1] s, floating[:] output) noexcept nogil:
 
     cdef int i
@@ -269,7 +269,7 @@ cdef void multilinear_interpolation_4d(floating[:] smin, floating[:] smax,
 
 
 cdef void multilinear_interpolation_5d(floating[:] smin, floating[:] smax,
-                                       int[:] orders, floating[:] V,
+                                       np.int64_t[:] orders, floating[:] V,
                                        int n_s, floating[:,::1] s, floating[:] output) noexcept nogil:
     cdef int i
     cdef floating lam_0, s_0, sn_0, snt_0

--- a/geotiepoints/multilinear_cython.pyx
+++ b/geotiepoints/multilinear_cython.pyx
@@ -10,7 +10,7 @@ import numpy as np
 np.import_array()
 
 
-def multilinear_interpolation(floating[:] smin, floating[:] smax, np.int64_t[:] orders, floating[:,::1] values, floating[:,::1] s):
+def multilinear_interpolation(floating[:] smin, floating[:] smax, long[:] orders, floating[:,::1] values, floating[:,::1] s):
 
     cdef Py_ssize_t d = s.shape[0]
     cdef Py_ssize_t n_s = s.shape[1]
@@ -46,7 +46,7 @@ def multilinear_interpolation(floating[:] smin, floating[:] smax, np.int64_t[:] 
 
 
 cdef void multilinear_interpolation_1d(floating[:] smin, floating[:] smax,
-                                       np.int64_t[:] orders, floating[:] V,
+                                       long[:] orders, floating[:] V,
                                        int n_s, floating[:,::1] s, floating[:] output) noexcept nogil:
 
     cdef int i
@@ -79,7 +79,7 @@ cdef void multilinear_interpolation_1d(floating[:] smin, floating[:] smax,
 
 
 cdef void multilinear_interpolation_2d(floating[:] smin, floating[:] smax,
-                                       np.int64_t[:] orders, floating[:] V,
+                                       long[:] orders, floating[:] V,
                                        int n_s, floating[:,::1] s, floating[:] output) noexcept nogil:
 
     cdef int i
@@ -124,7 +124,7 @@ cdef void multilinear_interpolation_2d(floating[:] smin, floating[:] smax,
 
 
 cdef void multilinear_interpolation_3d(floating[:] smin, floating[:] smax,
-                                       np.int64_t[:] orders, floating[:] V,
+                                       long[:] orders, floating[:] V,
                                        int n_s, floating[:,::1] s, floating[:] output) noexcept nogil:
     cdef int i
     cdef floating lam_0, s_0, sn_0, snt_0
@@ -184,7 +184,7 @@ cdef void multilinear_interpolation_3d(floating[:] smin, floating[:] smax,
 
 
 cdef void multilinear_interpolation_4d(floating[:] smin, floating[:] smax,
-                                       np.int64_t[:] orders, floating[:] V,
+                                       long[:] orders, floating[:] V,
                                        int n_s, floating[:,::1] s, floating[:] output) noexcept nogil:
 
     cdef int i
@@ -269,7 +269,7 @@ cdef void multilinear_interpolation_4d(floating[:] smin, floating[:] smax,
 
 
 cdef void multilinear_interpolation_5d(floating[:] smin, floating[:] smax,
-                                       np.int64_t[:] orders, floating[:] V,
+                                       long[:] orders, floating[:] V,
                                        int n_s, floating[:,::1] s, floating[:] output) noexcept nogil:
     cdef int i
     cdef floating lam_0, s_0, sn_0, snt_0


### PR DESCRIPTION
Downstream tests are failing in Satpy regarding dtype, but it only seems to be Windows so far. Let's see how CI behaves here.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes) -->
 - [ ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
