### PR TITLE
Fix gcc compiler warnings in MODIS interpolator

### DIFF
--- a/geotiepoints/_modis_interpolator.pyx
+++ b/geotiepoints/_modis_interpolator.pyx
@@ -214,12 +214,12 @@ cdef class MODISInterpolator:
     ) noexcept nogil:
         cdef unsigned int scan_idx
         cdef int i
-        cdef int fine_idx
-        cdef int half_scan_length = self._fine_pixels_per_coarse_pixel // 2
+        cdef unsigned int fine_idx
+        cdef unsigned int half_scan_length = self._fine_pixels_per_coarse_pixel // 2
         cdef unsigned int fine_pixels_per_scan = self._coarse_scan_length * self._fine_pixels_per_coarse_pixel
         for fine_idx in range(fine_pixels_per_scan):
             if fine_idx < half_scan_length:
-                y_view[fine_idx] = -half_scan_length + 0.5 + fine_idx
+                y_view[fine_idx] = 0.5 + fine_idx - half_scan_length
             elif fine_idx >= fine_pixels_per_scan - half_scan_length:
                 y_view[fine_idx] = (self._fine_pixels_per_coarse_pixel + 0.5) + (half_scan_length - (fine_pixels_per_scan - fine_idx))
             else:


### PR DESCRIPTION
We get warnings when the modis interpolator cython module is compiled. This PR fixes them. Because the tests pass I assume these changes are fine. Without the rearranging of the parameters in the one modified expression tests fail.


```

geotiepoints/_modis_interpolator.c: In function ‘__pyx_fuse_0__pyx_f_12geotiepoints_19_modis_interpolator_17MODISInterpolator__get_coords_1km’:
geotiepoints/_modis_interpolator.c:27438:33: warning: comparison of integer expressions of different signedness: ‘int’ and ‘unsigned int’ [-Wsign-compare]
27438 |   for (__pyx_t_3 = 0; __pyx_t_3 < __pyx_t_2; __pyx_t_3+=1) {
      |                                 ^
geotiepoints/_modis_interpolator.c:27482:35: warning: comparison of integer expressions of different signedness: ‘int’ and ‘unsigned int’ [-Wsign-compare]
27482 |     __pyx_t_4 = (__pyx_v_fine_idx >= (__pyx_v_fine_pixels_per_scan - __pyx_v_half_scan_length));
      |                                   ^~
geotiepoints/_modis_interpolator.c: In function ‘__pyx_fuse_1__pyx_f_12geotiepoints_19_modis_interpolator_17MODISInterpolator__get_coords_1km’:
geotiepoints/_modis_interpolator.c:27622:33: warning: comparison of integer expressions of different signedness: ‘int’ and ‘unsigned int’ [-Wsign-compare]
27622 |   for (__pyx_t_3 = 0; __pyx_t_3 < __pyx_t_2; __pyx_t_3+=1) {
      |                                 ^
geotiepoints/_modis_interpolator.c:27666:35: warning: comparison of integer expressions of different signedness: ‘int’ and ‘unsigned int’ [-Wsign-compare]
27666 |     __pyx_t_4 = (__pyx_v_fine_idx >= (__pyx_v_fine_pixels_per_scan - __pyx_v_half_scan_length));
      |                                   ^~
```

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes) -->
 - [ ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
